### PR TITLE
Convex hits fix

### DIFF
--- a/engine/dist/emptyproject.html
+++ b/engine/dist/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.7.22.21.54.9";
+var WICK_ENGINE_BUILD_VERSION = "2025.8.16.14.49.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -57824,7 +57824,7 @@ Wick.Clip = class extends Wick.Tickable {
     let intersections = [];
     let n = 0; // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
 
-    while ((!finished1 || !finished2) && n <= 2 * (hull1.length + hull2.length)) {
+    while ((!finished1 || !finished2) && n <= hull1.length + hull2.length) {
       n++; // line segments A is ab, B is cd
 
       let a = hull1[i1],
@@ -57839,18 +57839,42 @@ Wick.Clip = class extends Wick.Tickable {
       //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
       //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
 
-      let t2 = (c[1] - a[1] - (b[1] - a[1]) * (c[0] - a[0]) / (b[0] - a[0])) / ((b[1] - a[1]) * (d[0] - c[0]) / (b[0] - a[0]) - d[1] + c[1]);
-      let t1 = (c[0] + (d[0] - c[0]) * t2 - a[0]) / (b[0] - a[0]);
+      let dx1 = b[0] - a[0],
+          dy1 = b[1] - a[1],
+          dx2 = d[0] - c[0],
+          dy2 = d[1] - c[1],
+          dx = c[0] - a[0],
+          dy = c[1] - a[1];
+      let t2 = (dy - dy1 * dx / dx1) / (dy1 * dx2 / dx1 - dy2);
+      let t1 = (dx + dx2 * t2) / dx1;
 
-      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-        intersections.push({
-          x: a[0] + (b[0] - a[0]) * t1,
-          y: a[1] + (b[1] - a[1]) * t1
+      if (dx1 === 0 && (dx > 0 && d[0] < a[0] || dx < 0 && d[0] > a[0])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointY = c[1] + Math.abs(dx) * (dy2 / Math.abs(dx2)); //a[1] + (dy1) * t1;
+
+        if (pointY === Math.max(Math.min(a[1], pointY), b[1])) intersections.push({
+          x: a[0],
+          y: pointY
         });
       }
 
+      if (dy1 === 0 && (dy > 0 && d[1] < a[1] || dy < 0 && d[1] > a[1])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointX = c[0] + Math.abs(dy) * (dx2 / Math.abs(dy2)); //a[1] + (dy1) * t1;
+
+        if (pointX === Math.max(Math.min(a[0], pointX), b[0])) intersections.push({
+          x: pointX,
+          y: a[1]
+        });
+      }
+
+      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) intersections.push({
+        x: a[0] + dx1 * t1,
+        y: a[1] + dy1 * t1
+      });
+      if (window.intersectingRN.length > 8) window.intersectingRN.pop();
       let APointingToB = t1 > 1;
-      let BPointingToA = t2 > 1;
+      let BPointingToA = t2 > 1; //   console.info(`t1 ${t1}\nt2 ${t2}`);
 
       if (BPointingToA && !APointingToB) {
         // Advance B
@@ -60317,6 +60341,10 @@ Wick.Tools.Line = class extends Wick.Tool {
     });
     this.startPoint;
     this.endPoint;
+    this.hitResult = new this.paper.HitResult();
+    this.hoverPreview = new this.paper.Item({
+      insert: false
+    });
   }
 
   get doubleClickEnabled() {
@@ -60344,13 +60372,75 @@ Wick.Tools.Line = class extends Wick.Tool {
     this.path.remove();
   }
 
+  onMouseMove(e) {
+    // inherit mousemove class
+    super.onMouseMove(e); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // alt/ option or command/ control to snap to nearby selection
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5;
+      this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
+      this.startPoint = this.hitResult.segment.point;
+    } else {
+      this.startPoint = false;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
+  }
+
   onMouseDown(e) {
-    this.startPoint = e.point;
+    // check if there is a hoverpoint
+    // else use e.point for startPoint
+    if (!this.startPoint) this.startPoint = e.point;
   }
 
   onMouseDrag(e) {
-    this.path.remove();
-    this.endPoint = e.point;
+    this.path.remove(); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // snap to point if option/ alt or command/ control
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.endPoint = {
+        x: this.hitResult.segment.point.x,
+        y: this.hitResult.segment.point.y
+      };
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5; // display red when deleting line by dragging it to start point
+
+      this.hoverPreview.fillColor = this.endPoint.x === this.startPoint.x && this.endPoint.y === this.startPoint.y ? 'rgba(150,50,50,0.5)' : 'rgba(50,50,255,0.5)';
+    } else {
+      // default to cursor position
+      this.endPoint = e.point;
+    } // straight line
+
+
+    if (e.modifiers.shift) {
+      const dy = Math.abs(this.startPoint.y - e.point.y);
+      const dx = Math.abs(this.startPoint.x - e.point.x); // diagnol
+
+      if (dy && dx && dy / dx > 0.5 && dx / dy > 0.5) {
+        const diff = {
+          x: this.endPoint.x - this.startPoint.x,
+          y: this.endPoint.y - this.startPoint.y
+        };
+        this.endPoint = {
+          x: this.startPoint.x + (dy + dx) / 2 * diff.x / Math.abs(diff.x),
+          y: this.startPoint.y + (dy + dx) / 2 * diff.y / Math.abs(diff.y)
+        };
+      } else if (dy > dx) // straight vertical
+        this.endPoint.x = this.startPoint.x;else // straight horizontal
+        this.endPoint.y = this.startPoint.y;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
     this.path = new paper.Path.Line(this.startPoint, this.endPoint);
     this.path.strokeCap = 'round';
     this.path.strokeColor = this.getSetting('strokeColor').rgba;
@@ -60358,12 +60448,41 @@ Wick.Tools.Line = class extends Wick.Tool {
   }
 
   onMouseUp(e) {
+    this.hoverPreview.remove();
     this.path.remove();
-    this.addPathToProject(this.path);
-    this.fireEvent({
-      eventName: 'canvasModified',
-      actionName: 'line'
+
+    if (this.endPoint.x !== this.startPoint.x || this.endPoint.y !== this.startPoint.y) {
+      this.addPathToProject(this.path);
+      this.fireEvent({
+        eventName: 'canvasModified',
+        actionName: 'line'
+      });
+    }
+  } // todo: clean this function -H.A.
+
+
+  _updateHitResult(e) {
+    var newHitResult = this.paper.project.hitTest(e.point, {
+      fill: false,
+      stroke: false,
+      curves: false,
+      segments: true,
+      handles: false,
+      tolerance: 10,
+      match: result => {
+        return result.item !== this.hoverPreview && !result.item.data.isBorder;
+      }
     });
+    if (!newHitResult) newHitResult = new this.paper.HitResult();
+
+    if (newHitResult.item && !newHitResult.item.data.isSelectionBoxGUI) {
+      // You can't select children of compound paths, you can only select the whole thing.
+      if (newHitResult.item.parent.className === 'CompoundPath') {
+        newHitResult.item = newHitResult.item.parent;
+      }
+    }
+
+    return newHitResult;
   }
 
 };

--- a/engine/dist/wickengine.js
+++ b/engine/dist/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.7.22.21.54.9";
+var WICK_ENGINE_BUILD_VERSION = "2025.8.16.14.49.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -57809,7 +57809,7 @@ Wick.Clip = class extends Wick.Tickable {
     let intersections = [];
     let n = 0; // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
 
-    while ((!finished1 || !finished2) && n <= 2 * (hull1.length + hull2.length)) {
+    while ((!finished1 || !finished2) && n <= hull1.length + hull2.length) {
       n++; // line segments A is ab, B is cd
 
       let a = hull1[i1],
@@ -57824,18 +57824,42 @@ Wick.Clip = class extends Wick.Tickable {
       //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
       //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
 
-      let t2 = (c[1] - a[1] - (b[1] - a[1]) * (c[0] - a[0]) / (b[0] - a[0])) / ((b[1] - a[1]) * (d[0] - c[0]) / (b[0] - a[0]) - d[1] + c[1]);
-      let t1 = (c[0] + (d[0] - c[0]) * t2 - a[0]) / (b[0] - a[0]);
+      let dx1 = b[0] - a[0],
+          dy1 = b[1] - a[1],
+          dx2 = d[0] - c[0],
+          dy2 = d[1] - c[1],
+          dx = c[0] - a[0],
+          dy = c[1] - a[1];
+      let t2 = (dy - dy1 * dx / dx1) / (dy1 * dx2 / dx1 - dy2);
+      let t1 = (dx + dx2 * t2) / dx1;
 
-      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-        intersections.push({
-          x: a[0] + (b[0] - a[0]) * t1,
-          y: a[1] + (b[1] - a[1]) * t1
+      if (dx1 === 0 && (dx > 0 && d[0] < a[0] || dx < 0 && d[0] > a[0])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointY = c[1] + Math.abs(dx) * (dy2 / Math.abs(dx2)); //a[1] + (dy1) * t1;
+
+        if (pointY === Math.max(Math.min(a[1], pointY), b[1])) intersections.push({
+          x: a[0],
+          y: pointY
         });
       }
 
+      if (dy1 === 0 && (dy > 0 && d[1] < a[1] || dy < 0 && d[1] > a[1])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointX = c[0] + Math.abs(dy) * (dx2 / Math.abs(dy2)); //a[1] + (dy1) * t1;
+
+        if (pointX === Math.max(Math.min(a[0], pointX), b[0])) intersections.push({
+          x: pointX,
+          y: a[1]
+        });
+      }
+
+      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) intersections.push({
+        x: a[0] + dx1 * t1,
+        y: a[1] + dy1 * t1
+      });
+      if (window.intersectingRN.length > 8) window.intersectingRN.pop();
       let APointingToB = t1 > 1;
-      let BPointingToA = t2 > 1;
+      let BPointingToA = t2 > 1; //   console.info(`t1 ${t1}\nt2 ${t2}`);
 
       if (BPointingToA && !APointingToB) {
         // Advance B
@@ -60302,6 +60326,10 @@ Wick.Tools.Line = class extends Wick.Tool {
     });
     this.startPoint;
     this.endPoint;
+    this.hitResult = new this.paper.HitResult();
+    this.hoverPreview = new this.paper.Item({
+      insert: false
+    });
   }
 
   get doubleClickEnabled() {
@@ -60329,13 +60357,75 @@ Wick.Tools.Line = class extends Wick.Tool {
     this.path.remove();
   }
 
+  onMouseMove(e) {
+    // inherit mousemove class
+    super.onMouseMove(e); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // alt/ option or command/ control to snap to nearby selection
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5;
+      this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
+      this.startPoint = this.hitResult.segment.point;
+    } else {
+      this.startPoint = false;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
+  }
+
   onMouseDown(e) {
-    this.startPoint = e.point;
+    // check if there is a hoverpoint
+    // else use e.point for startPoint
+    if (!this.startPoint) this.startPoint = e.point;
   }
 
   onMouseDrag(e) {
-    this.path.remove();
-    this.endPoint = e.point;
+    this.path.remove(); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // snap to point if option/ alt or command/ control
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.endPoint = {
+        x: this.hitResult.segment.point.x,
+        y: this.hitResult.segment.point.y
+      };
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5; // display red when deleting line by dragging it to start point
+
+      this.hoverPreview.fillColor = this.endPoint.x === this.startPoint.x && this.endPoint.y === this.startPoint.y ? 'rgba(150,50,50,0.5)' : 'rgba(50,50,255,0.5)';
+    } else {
+      // default to cursor position
+      this.endPoint = e.point;
+    } // straight line
+
+
+    if (e.modifiers.shift) {
+      const dy = Math.abs(this.startPoint.y - e.point.y);
+      const dx = Math.abs(this.startPoint.x - e.point.x); // diagnol
+
+      if (dy && dx && dy / dx > 0.5 && dx / dy > 0.5) {
+        const diff = {
+          x: this.endPoint.x - this.startPoint.x,
+          y: this.endPoint.y - this.startPoint.y
+        };
+        this.endPoint = {
+          x: this.startPoint.x + (dy + dx) / 2 * diff.x / Math.abs(diff.x),
+          y: this.startPoint.y + (dy + dx) / 2 * diff.y / Math.abs(diff.y)
+        };
+      } else if (dy > dx) // straight vertical
+        this.endPoint.x = this.startPoint.x;else // straight horizontal
+        this.endPoint.y = this.startPoint.y;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
     this.path = new paper.Path.Line(this.startPoint, this.endPoint);
     this.path.strokeCap = 'round';
     this.path.strokeColor = this.getSetting('strokeColor').rgba;
@@ -60343,12 +60433,41 @@ Wick.Tools.Line = class extends Wick.Tool {
   }
 
   onMouseUp(e) {
+    this.hoverPreview.remove();
     this.path.remove();
-    this.addPathToProject(this.path);
-    this.fireEvent({
-      eventName: 'canvasModified',
-      actionName: 'line'
+
+    if (this.endPoint.x !== this.startPoint.x || this.endPoint.y !== this.startPoint.y) {
+      this.addPathToProject(this.path);
+      this.fireEvent({
+        eventName: 'canvasModified',
+        actionName: 'line'
+      });
+    }
+  } // todo: clean this function -H.A.
+
+
+  _updateHitResult(e) {
+    var newHitResult = this.paper.project.hitTest(e.point, {
+      fill: false,
+      stroke: false,
+      curves: false,
+      segments: true,
+      handles: false,
+      tolerance: 10,
+      match: result => {
+        return result.item !== this.hoverPreview && !result.item.data.isBorder;
+      }
     });
+    if (!newHitResult) newHitResult = new this.paper.HitResult();
+
+    if (newHitResult.item && !newHitResult.item.data.isSelectionBoxGUI) {
+      // You can't select children of compound paths, you can only select the whole thing.
+      if (newHitResult.item.parent.className === 'CompoundPath') {
+        newHitResult.item = newHitResult.item.parent;
+      }
+    }
+
+    return newHitResult;
   }
 
 };

--- a/engine/src/base/Clip.js
+++ b/engine/src/base/Clip.js
@@ -708,182 +708,206 @@ Wick.Clip = class extends Wick.Tickable {
      * @returns {object} Hit information
      */
     convexHits(other, options) {
-        // Efficient check first
-        let bounds1 = this.absoluteBounds;
-        let bounds2 = other.absoluteBounds;
-        // TODO: write intersects so we don't rely on paper Rectangle objects
-        if (!bounds1.intersects(bounds2)) {
-            return null;
-        }
-        let c1 = bounds1.center;
-        let c2 = bounds2.center;
+    // Efficient check first
+    let bounds1 = this.absoluteBounds;
+    let bounds2 = other.absoluteBounds; // TODO: write intersects so we don't rely on paper Rectangle objects
 
-        // clockwise arrays of points in format [[x1, y1], [x2, y2], ...]
-        let hull1 = this.convexHull;
-        let hull2 = other.convexHull;
-
-        let finished1 = false;
-        let finished2 = false;
-
-        let i1 = hull1.length - 1;
-        let i2 = hull2.length - 1;
-
-        let intersections = [];
-
-        let n = 0;
-        // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
-        while ((!finished1 || !finished2) && n <= 2 * (hull1.length + hull2.length)) {
-            n++;
-            // line segments A is ab, B is cd
-            let a = hull1[i1],
-            b = hull1[((i1 - 1) % hull1.length + hull1.length) % hull1.length],
-            c = hull2[i2],
-            d = hull2[((i2 - 1) % hull2.length + hull2.length) % hull2.length];
-
-            //Use parametric line intersection
-            //<x,y> = a + (b - a)t1
-            //<x,y> = c + (d - c)t2
-            //a + (b - a)t1 = c + (d - c)t2
-            //t1 = (c.x + (d.x - c.x)t2 - a.x) / (b.x - a.x)
-            //a.y + (b.y - a.y) * (c.x + (d.x - c.x)t2 - a.x) / (b.x - a.x) = c.y + (d.y - c.y)t2
-            //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
-            //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
-            let t2 = (c[1] - a[1] - (b[1] - a[1]) * (c[0] - a[0]) / (b[0] - a[0]))  /  ((b[1] - a[1]) * (d[0] - c[0]) / (b[0] - a[0]) - d[1] + c[1]);
-            let t1 = (c[0] + (d[0] - c[0]) * t2 - a[0]) / (b[0] - a[0]);
-
-            if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-                intersections.push({x: a[0] + (b[0] - a[0])*t1, y: a[1] + (b[1] - a[1]) * t1});
-            }
-
-            let APointingToB = t1 > 1;
-            let BPointingToA = t2 > 1;
-
-            if (BPointingToA && !APointingToB) {
-                // Advance B
-                i2 -= 1;
-                if (i2 < 0) {
-                    finished2 = true;
-                    i2 += hull2.length;
-                }
-            }
-            else if (APointingToB && !BPointingToA) {
-                // Advance A
-                i1 -= 1;
-                if (i1 < 0) {
-                    finished1 = true;
-                    i1 += hull1.length;
-                }
-            }
-            else {
-                // Advance outside
-                if (this.cw(a[0], a[1], b[0], b[1], d[0], d[1])) {
-                    // Advance B
-                    i2 -= 1;
-                    if (i2 < 0) {
-                        finished2 = true;
-                        i2 += hull2.length;
-                    }
-                }
-                else {
-                    // Advance A
-                    i1 -= 1;
-                    if (i1 < 0) {
-                        finished1 = true;
-                        i1 += hull1.length;
-                    }
-                }
-            }
-        }
-        // Ok, we have all the intersections now
-        let avgIntersection = {x: 0, y: 0};
-        if (intersections.length === 0) {
-            avgIntersection.x = bounds1.width < bounds2.width ? c1.x : c2.x;
-            avgIntersection.y = bounds1.width < bounds2.width ? c1.y : c2.y;
-        }
-        else {
-            for (let i = 0; i < intersections.length; i++) {
-                avgIntersection.x += intersections[i].x;
-                avgIntersection.y += intersections[i].y;
-            }
-            avgIntersection.x /= intersections.length;
-            avgIntersection.y /= intersections.length;
-        }
-
-        let result = {};
-        if (options.intersections) {
-            result.intersections = intersections;
-        }
-        if (options.offset) {
-            // Calculate offset by taking the center of mass of the intersection, call it P,
-            // get the radius from P on this convex hull in the direction
-            // from this center to that center,
-            // Then, the offset is a vector in the direction from that center to this center
-            // with magnitude of that radius
-
-            let targetTheta = Math.atan2(c2.y - c1.y, c2.x - c1.x); //from c1 to c2
-            let r = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
-            targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
-            r += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
-
-            let directionX = c1.x - c2.x;
-            let directionY = c1.y - c2.y;
-            let mag = Math.sqrt(directionX*directionX + directionY*directionY);
-            directionX *= r / mag;
-            directionY *= r / mag;
-            result.offsetX = directionX;
-            result.offsetY = directionY;
-        }
-        if (options.overlap) {
-            //same as offset except instead of center to center, 
-            //we will move perpendicular to the best fit line
-            //of the intersection points
-
-            let directionX, directionY;
-            if (intersections.length < 2) {
-                directionX = c2.x - c1.x;
-                directionY = c2.y - c1.y;
-            }
-            else {
-                let max_d = 0;
-                for (let i = 1; i < intersections.length; i++) {
-                    let d = (intersections[i].y - intersections[0].y) * (intersections[i].y - intersections[0].y) +
-                        (intersections[i].x - intersections[0].x) * (intersections[i].x - intersections[0].x);
-                    if (d > max_d) {
-                        max_d = d;
-                        directionX = -(intersections[i].y - intersections[0].y);
-                        directionY = intersections[i].x - intersections[0].x;
-                        if (directionX * (c1.x - avgIntersection.x) + directionY * (c1.y - avgIntersection.y) > 0) {
-                            directionX = -directionX;
-                            directionY = -directionY;
-                        }
-                    }
-                }
-            }
-
-            let targetTheta = Math.atan2(directionY, directionX); 
-            let r = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
-            targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
-            r += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
-
-            let r2 = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
-            targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
-            r2 += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
-
-            if (r2 < r) {
-                r = r2;
-                directionX *= -1;
-                directionY *= -1;
-            }
-
-
-            let mag = Math.sqrt(directionX*directionX + directionY*directionY);
-            directionX *= -r / mag;
-            directionY *= -r / mag;
-            result.overlapX = directionX;
-            result.overlapY = directionY;
-        }
-        return result;
+    if (!bounds1.intersects(bounds2)) {
+      return null;
     }
+
+
+    let c1 = bounds1.center;
+    let c2 = bounds2.center; // clockwise arrays of points in format [[x1, y1], [x2, y2], ...]
+
+    let hull1 = this.convexHull;
+    let hull2 = other.convexHull;
+    let finished1 = false;
+    let finished2 = false;
+    let i1 = hull1.length - 1;
+    let i2 = hull2.length - 1;
+    let intersections = [];
+    let n = 0; // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
+
+    while ((!finished1 || !finished2) && n <= (hull1.length + hull2.length)) {
+      n++; // line segments A is ab, B is cd
+
+      let a = hull1[i1],
+          b = hull1[((i1 - 1) % hull1.length + hull1.length) % hull1.length],
+          c = hull2[i2],
+          d = hull2[((i2 - 1) % hull2.length + hull2.length) % hull2.length]; //Use parametric line intersection
+      //<x,y> = a + (b - a)t1
+      //<x,y> = c + (d - c)t2
+      //a + (b - a)t1 = c + (d - c)t2
+      //t1 = (c.x + (d.x - c.x)t2 - a.x) / (b.x - a.x)
+      //a.y + (b.y - a.y) * (c.x + (d.x - c.x)t2 - a.x) / (b.x - a.x) = c.y + (d.y - c.y)t2
+      //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
+      //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
+
+	  let dx1 = b[0] - a[0],
+		  dy1 = b[1] - a[1],
+		  dx2 = d[0] - c[0],
+		  dy2 = d[1] - c[1],
+		  dx  = c[0] - a[0],
+		  dy  = c[1] - a[1]
+
+      let t2 = (dy - dy1*dx / dx1) / (dy1*dx2 / dx1 - dy2);
+      let t1 = (dx + dx2*t2 ) / dx1;
+
+	  if(dx1 === 0 && ((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))){ // test to see if we have a divide by zero error somewhere
+		let pointY = (c[1] + Math.abs(dx)*(dy2/Math.abs(dx2))); //a[1] + (dy1) * t1;
+		if(pointY === Math.max(Math.min(a[1],pointY),b[1]))
+			intersections.push({x: a[0],y: pointY});
+	  }
+	  if(dy1 === 0 && ((dy>0 && d[1]<a[1]) || (dy<0 && d[1]>a[1]))){ // test to see if we have a divide by zero error somewhere
+		let pointX = (c[0] + Math.abs(dy)*(dx2/Math.abs(dy2))); //a[1] + (dy1) * t1;
+		if(pointX === Math.max(Math.min(a[0],pointX),b[0]))
+			intersections.push({x: pointX, y: a[1]});
+	  }
+	  if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1)
+        intersections.push({ x: a[0]+(dx1)*t1, y: a[1]+(dy1)*t1 });
+
+	  if(window.intersectingRN.length>8)
+		window.intersectingRN.pop();
+
+      let APointingToB = t1 > 1;
+      let BPointingToA = t2 > 1;
+	//   console.info(`t1 ${t1}\nt2 ${t2}`);
+
+      if (BPointingToA && !APointingToB) {
+        // Advance B
+        i2 -= 1;
+
+        if (i2 < 0) {
+          finished2 = true;
+          i2 += hull2.length;
+        }
+      } else if (APointingToB && !BPointingToA) {
+        // Advance A
+        i1 -= 1;
+
+        if (i1 < 0) {
+          finished1 = true;
+          i1 += hull1.length;
+        }
+      } else {
+        // Advance outside
+        if (this.cw(a[0], a[1], b[0], b[1], d[0], d[1])) {
+          // Advance B
+          i2 -= 1;
+
+          if (i2 < 0) {
+            finished2 = true;
+            i2 += hull2.length;
+          }
+        } else {
+          // Advance A
+          i1 -= 1;
+
+          if (i1 < 0) {
+            finished1 = true;
+            i1 += hull1.length;
+          }
+        }
+      }
+    } // Ok, we have all the intersections now
+
+
+    let avgIntersection = {
+      x: 0,
+      y: 0
+    };
+
+    if (intersections.length === 0) {
+      avgIntersection.x = bounds1.width < bounds2.width ? c1.x : c2.x;
+      avgIntersection.y = bounds1.width < bounds2.width ? c1.y : c2.y;
+    } else {
+      for (let i = 0; i < intersections.length; i++) {
+        avgIntersection.x += intersections[i].x;
+        avgIntersection.y += intersections[i].y;
+      }
+
+      avgIntersection.x /= intersections.length;
+      avgIntersection.y /= intersections.length;
+    }
+
+    let result = {};
+
+    if (options.intersections) {
+      result.intersections = intersections;
+    }
+
+    if (options.offset) {
+      // Calculate offset by taking the center of mass of the intersection, call it P,
+      // get the radius from P on this convex hull in the direction
+      // from this center to that center,
+      // Then, the offset is a vector in the direction from that center to this center
+      // with magnitude of that radius
+      let targetTheta = Math.atan2(c2.y - c1.y, c2.x - c1.x); //from c1 to c2
+
+      let r = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
+      targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
+      r += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
+      let directionX = c1.x - c2.x;
+      let directionY = c1.y - c2.y;
+      let mag = Math.sqrt(directionX * directionX + directionY * directionY);
+      directionX *= r / mag;
+      directionY *= r / mag;
+      result.offsetX = directionX;
+      result.offsetY = directionY;
+    }
+
+    if (options.overlap) {
+      //same as offset except instead of center to center, 
+      //we will move perpendicular to the best fit line
+      //of the intersection points
+      let directionX, directionY;
+
+      if (intersections.length < 2) {
+        directionX = c2.x - c1.x;
+        directionY = c2.y - c1.y;
+      } else {
+        let max_d = 0;
+
+        for (let i = 1; i < intersections.length; i++) {
+          let d = (intersections[i].y - intersections[0].y) * (intersections[i].y - intersections[0].y) + (intersections[i].x - intersections[0].x) * (intersections[i].x - intersections[0].x);
+
+          if (d > max_d) {
+            max_d = d;
+            directionX = -(intersections[i].y - intersections[0].y);
+            directionY = intersections[i].x - intersections[0].x;
+
+            if (directionX * (c1.x - avgIntersection.x) + directionY * (c1.y - avgIntersection.y) > 0) {
+              directionX = -directionX;
+              directionY = -directionY;
+            }
+          }
+        }
+      }
+
+      let targetTheta = Math.atan2(directionY, directionX);
+      let r = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
+      targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
+      r += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
+      let r2 = this.radiusAtPointInDirection(hull1, avgIntersection, targetTheta);
+      targetTheta = (targetTheta + Math.PI) % (2 * Math.PI);
+      r2 += this.radiusAtPointInDirection(hull2, avgIntersection, targetTheta);
+
+      if (r2 < r) {
+        r = r2;
+        directionX *= -1;
+        directionY *= -1;
+      }
+
+      let mag = Math.sqrt(directionX * directionX + directionY * directionY);
+      directionX *= -r / mag;
+      directionY *= -r / mag;
+      result.overlapX = directionX;
+      result.overlapY = directionY;
+    }
+
+    return result;
+  }
 
     /**
      * Casts a ray from p in the direction targetTheta and intersects it with the hull ch,

--- a/public/corelibs/wick-engine/emptyproject.html
+++ b/public/corelibs/wick-engine/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.7.22.21.54.9";
+var WICK_ENGINE_BUILD_VERSION = "2025.8.16.14.49.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -57824,7 +57824,7 @@ Wick.Clip = class extends Wick.Tickable {
     let intersections = [];
     let n = 0; // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
 
-    while ((!finished1 || !finished2) && n <= 2 * (hull1.length + hull2.length)) {
+    while ((!finished1 || !finished2) && n <= hull1.length + hull2.length) {
       n++; // line segments A is ab, B is cd
 
       let a = hull1[i1],
@@ -57839,18 +57839,42 @@ Wick.Clip = class extends Wick.Tickable {
       //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
       //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
 
-      let t2 = (c[1] - a[1] - (b[1] - a[1]) * (c[0] - a[0]) / (b[0] - a[0])) / ((b[1] - a[1]) * (d[0] - c[0]) / (b[0] - a[0]) - d[1] + c[1]);
-      let t1 = (c[0] + (d[0] - c[0]) * t2 - a[0]) / (b[0] - a[0]);
+      let dx1 = b[0] - a[0],
+          dy1 = b[1] - a[1],
+          dx2 = d[0] - c[0],
+          dy2 = d[1] - c[1],
+          dx = c[0] - a[0],
+          dy = c[1] - a[1];
+      let t2 = (dy - dy1 * dx / dx1) / (dy1 * dx2 / dx1 - dy2);
+      let t1 = (dx + dx2 * t2) / dx1;
 
-      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-        intersections.push({
-          x: a[0] + (b[0] - a[0]) * t1,
-          y: a[1] + (b[1] - a[1]) * t1
+      if (dx1 === 0 && (dx > 0 && d[0] < a[0] || dx < 0 && d[0] > a[0])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointY = c[1] + Math.abs(dx) * (dy2 / Math.abs(dx2)); //a[1] + (dy1) * t1;
+
+        if (pointY === Math.max(Math.min(a[1], pointY), b[1])) intersections.push({
+          x: a[0],
+          y: pointY
         });
       }
 
+      if (dy1 === 0 && (dy > 0 && d[1] < a[1] || dy < 0 && d[1] > a[1])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointX = c[0] + Math.abs(dy) * (dx2 / Math.abs(dy2)); //a[1] + (dy1) * t1;
+
+        if (pointX === Math.max(Math.min(a[0], pointX), b[0])) intersections.push({
+          x: pointX,
+          y: a[1]
+        });
+      }
+
+      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) intersections.push({
+        x: a[0] + dx1 * t1,
+        y: a[1] + dy1 * t1
+      });
+      if (window.intersectingRN.length > 8) window.intersectingRN.pop();
       let APointingToB = t1 > 1;
-      let BPointingToA = t2 > 1;
+      let BPointingToA = t2 > 1; //   console.info(`t1 ${t1}\nt2 ${t2}`);
 
       if (BPointingToA && !APointingToB) {
         // Advance B
@@ -60317,6 +60341,10 @@ Wick.Tools.Line = class extends Wick.Tool {
     });
     this.startPoint;
     this.endPoint;
+    this.hitResult = new this.paper.HitResult();
+    this.hoverPreview = new this.paper.Item({
+      insert: false
+    });
   }
 
   get doubleClickEnabled() {
@@ -60344,13 +60372,75 @@ Wick.Tools.Line = class extends Wick.Tool {
     this.path.remove();
   }
 
+  onMouseMove(e) {
+    // inherit mousemove class
+    super.onMouseMove(e); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // alt/ option or command/ control to snap to nearby selection
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5;
+      this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
+      this.startPoint = this.hitResult.segment.point;
+    } else {
+      this.startPoint = false;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
+  }
+
   onMouseDown(e) {
-    this.startPoint = e.point;
+    // check if there is a hoverpoint
+    // else use e.point for startPoint
+    if (!this.startPoint) this.startPoint = e.point;
   }
 
   onMouseDrag(e) {
-    this.path.remove();
-    this.endPoint = e.point;
+    this.path.remove(); // remove the hover preview
+
+    this.hoverPreview.remove(); // find what's under the cursor
+
+    this.hitResult = this._updateHitResult(e); // snap to point if option/ alt or command/ control
+
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.endPoint = {
+        x: this.hitResult.segment.point.x,
+        y: this.hitResult.segment.point.y
+      };
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5; // display red when deleting line by dragging it to start point
+
+      this.hoverPreview.fillColor = this.endPoint.x === this.startPoint.x && this.endPoint.y === this.startPoint.y ? 'rgba(150,50,50,0.5)' : 'rgba(50,50,255,0.5)';
+    } else {
+      // default to cursor position
+      this.endPoint = e.point;
+    } // straight line
+
+
+    if (e.modifiers.shift) {
+      const dy = Math.abs(this.startPoint.y - e.point.y);
+      const dx = Math.abs(this.startPoint.x - e.point.x); // diagnol
+
+      if (dy && dx && dy / dx > 0.5 && dx / dy > 0.5) {
+        const diff = {
+          x: this.endPoint.x - this.startPoint.x,
+          y: this.endPoint.y - this.startPoint.y
+        };
+        this.endPoint = {
+          x: this.startPoint.x + (dy + dx) / 2 * diff.x / Math.abs(diff.x),
+          y: this.startPoint.y + (dy + dx) / 2 * diff.y / Math.abs(diff.y)
+        };
+      } else if (dy > dx) // straight vertical
+        this.endPoint.x = this.startPoint.x;else // straight horizontal
+        this.endPoint.y = this.startPoint.y;
+    }
+
+    this.hoverPreview.data.wickType = 'gui';
     this.path = new paper.Path.Line(this.startPoint, this.endPoint);
     this.path.strokeCap = 'round';
     this.path.strokeColor = this.getSetting('strokeColor').rgba;
@@ -60358,12 +60448,41 @@ Wick.Tools.Line = class extends Wick.Tool {
   }
 
   onMouseUp(e) {
+    this.hoverPreview.remove();
     this.path.remove();
-    this.addPathToProject(this.path);
-    this.fireEvent({
-      eventName: 'canvasModified',
-      actionName: 'line'
+
+    if (this.endPoint.x !== this.startPoint.x || this.endPoint.y !== this.startPoint.y) {
+      this.addPathToProject(this.path);
+      this.fireEvent({
+        eventName: 'canvasModified',
+        actionName: 'line'
+      });
+    }
+  } // todo: clean this function -H.A.
+
+
+  _updateHitResult(e) {
+    var newHitResult = this.paper.project.hitTest(e.point, {
+      fill: false,
+      stroke: false,
+      curves: false,
+      segments: true,
+      handles: false,
+      tolerance: 10,
+      match: result => {
+        return result.item !== this.hoverPreview && !result.item.data.isBorder;
+      }
     });
+    if (!newHitResult) newHitResult = new this.paper.HitResult();
+
+    if (newHitResult.item && !newHitResult.item.data.isSelectionBoxGUI) {
+      // You can't select children of compound paths, you can only select the whole thing.
+      if (newHitResult.item.parent.className === 'CompoundPath') {
+        newHitResult.item = newHitResult.item.parent;
+      }
+    }
+
+    return newHitResult;
   }
 
 };

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -57838,31 +57838,15 @@ Wick.Clip = class extends Wick.Tickable {
 	  if(isNaN(t1) || isNaN(t2)){
 		let pointY = c[1] + Math.abs(dx)*(dy2/Math.abs(dx2)); //a[1] + (dy1) * t1;
 		// if(pointY < Math.max(a[1],b[1]) && pointY > Math.min(a[1],b[1]))
-		if(
-			true ||
-			((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))
-			&&
-			pointY < Math.max(a[1],b[1])
-			&&
-			pointY > Math.min(a[1],b[1])
-		)
-		intersections.push({
-          x: a[0],
-          y: pointY
-        });
+		if(((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))
+			&& pointY === Math.max(Math.min(a[1],pointY),b[1]))
+		intersections.push({x: a[0],y: pointY});
 	  }
 
-      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-        intersections.push({
-          x: a[0] + (dx1) * t1,
-          y: a[1] + (dy1) * t1
-        });
-      }
-	
-			/*
+      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1)
+        intersections.push({ x: a[0]+(dx1)*t1, y: a[1]+(dy1)*t1 });
 
-
-
+/*
            ____   ___    ________     _____         __________ 
 		  //  /  /  /   //  ____/    //   /        //   ___  /
 		 //  /__/  /   //  /__,     //   /        //   /__/ /
@@ -57872,13 +57856,7 @@ Wick.Clip = class extends Wick.Tickable {
 	. . .
 		   save yourself too . . .
 		   .  . ..…… RUN BEFORE ITS TOO LATE FOR YOU
-		   
-		   
-
-
-		*/
-
-
+*/
 
 	  if(window.intersectingRN.length>8)
 		window.intersectingRN.pop();

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.7.22.21.54.9";
+var WICK_ENGINE_BUILD_VERSION = "2025.8.16.14.49.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -57797,7 +57797,6 @@ Wick.Clip = class extends Wick.Tickable {
       return null;
     }
 
-
     let c1 = bounds1.center;
     let c2 = bounds2.center; // clockwise arrays of points in format [[x1, y1], [x2, y2], ...]
 
@@ -57810,7 +57809,7 @@ Wick.Clip = class extends Wick.Tickable {
     let intersections = [];
     let n = 0; // Algorithm from https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf
 
-    while ((!finished1 || !finished2) && n <= 2 * (hull1.length + hull2.length)) {
+    while ((!finished1 || !finished2) && n <= hull1.length + hull2.length) {
       n++; // line segments A is ab, B is cd
 
       let a = hull1[i1],
@@ -57825,44 +57824,42 @@ Wick.Clip = class extends Wick.Tickable {
       //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
       //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
 
-	  let dx1 = b[0] - a[0],
-		  dy1 = b[1] - a[1],
-		  dx2 = d[0] - c[0],
-		  dy2 = d[1] - c[1],
-		  dx  = c[0] - a[0],
-		  dy  = c[1] - a[1]
+      let dx1 = b[0] - a[0],
+          dy1 = b[1] - a[1],
+          dx2 = d[0] - c[0],
+          dy2 = d[1] - c[1],
+          dx = c[0] - a[0],
+          dy = c[1] - a[1];
+      let t2 = (dy - dy1 * dx / dx1) / (dy1 * dx2 / dx1 - dy2);
+      let t1 = (dx + dx2 * t2) / dx1;
 
-      let t2 = (dy - dy1*dx / dx1) / (dy1*dx2 / dx1 - dy2);
-      let t1 = (dx + dx2*t2 ) / dx1;
+      if (dx1 === 0 && (dx > 0 && d[0] < a[0] || dx < 0 && d[0] > a[0])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointY = c[1] + Math.abs(dx) * (dy2 / Math.abs(dx2)); //a[1] + (dy1) * t1;
 
-	  if(isNaN(t1) || isNaN(t2)){
-		let pointY = c[1] + Math.abs(dx)*(dy2/Math.abs(dx2)); //a[1] + (dy1) * t1;
-		if(((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))
-			&& pointY === Math.max(Math.min(a[1],pointY),b[1]))
-		intersections.push({x: a[0],y: pointY});
-	  }
+        if (pointY === Math.max(Math.min(a[1], pointY), b[1])) intersections.push({
+          x: a[0],
+          y: pointY
+        });
+      }
 
-      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1)
-        intersections.push({ x: a[0]+(dx1)*t1, y: a[1]+(dy1)*t1 });
+      if (dy1 === 0 && (dy > 0 && d[1] < a[1] || dy < 0 && d[1] > a[1])) {
+        // test to see if we have a divide by zero error somewhere
+        let pointX = c[0] + Math.abs(dy) * (dx2 / Math.abs(dy2)); //a[1] + (dy1) * t1;
 
-/*
-           ____   ___    ________     _____         __________ 
-		  //  /  /  /   //  ____/    //   /        //   ___  /
-		 //  /__/  /   //  /__,     //   /        //   /__/ /
-    	//  ___   |   //  ____/    //   /        //   _____/  
-	   //  /  /  /   //  /____    //   /____    //   /      
-	  //__/  /__/   //_______/   //________/   //___/      ME
-	. . .
-		   save yourself too . . .
-		   .  . ..…… RUN BEFORE ITS TOO LATE FOR YOU
-*/
+        if (pointX === Math.max(Math.min(a[0], pointX), b[0])) intersections.push({
+          x: pointX,
+          y: a[1]
+        });
+      }
 
-	  if(window.intersectingRN.length>8)
-		window.intersectingRN.pop();
-
+      if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) intersections.push({
+        x: a[0] + dx1 * t1,
+        y: a[1] + dy1 * t1
+      });
+      if (window.intersectingRN.length > 8) window.intersectingRN.pop();
       let APointingToB = t1 > 1;
-      let BPointingToA = t2 > 1;
-	//   console.info(`t1 ${t1}\nt2 ${t2}`);
+      let BPointingToA = t2 > 1; //   console.info(`t1 ${t1}\nt2 ${t2}`);
 
       if (BPointingToA && !APointingToB) {
         // Advance B
@@ -60329,10 +60326,10 @@ Wick.Tools.Line = class extends Wick.Tool {
     });
     this.startPoint;
     this.endPoint;
-	this.hitResult = new this.paper.HitResult();
-	this.hoverPreview = new this.paper.Item({
-		insert: false
-	});
+    this.hitResult = new this.paper.HitResult();
+    this.hoverPreview = new this.paper.Item({
+      insert: false
+    });
   }
 
   get doubleClickEnabled() {
@@ -60361,90 +60358,74 @@ Wick.Tools.Line = class extends Wick.Tool {
   }
 
   onMouseMove(e) {
-	// inherit mousemove class
-	super.onMouseMove(e); 
+    // inherit mousemove class
+    super.onMouseMove(e); // remove the hover preview
 
-	// remove the hover preview
-	this.hoverPreview.remove();
+    this.hoverPreview.remove(); // find what's under the cursor
 
-	// find what's under the cursor
-	this.hitResult = this._updateHitResult(e);
+    this.hitResult = this._updateHitResult(e); // alt/ option or command/ control to snap to nearby selection
 
-	// alt/ option or command/ control to snap to nearby selection
-	if( (e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option ) && this.hitResult.type === 'segment') {
-		this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5/this.paper.view.zoom);
-		this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
-		this.hoverPreview.strokeWidth = 1.5;
-		this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5;
+      this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
+      this.startPoint = this.hitResult.segment.point;
+    } else {
+      this.startPoint = false;
+    }
 
-		this.startPoint = this.hitResult.segment.point;
-	}else{
-		this.startPoint = false;
-	}
-
-	this.hoverPreview.data.wickType = 'gui';
+    this.hoverPreview.data.wickType = 'gui';
   }
 
   onMouseDown(e) {
-	
-	// check if there is a hoverpoint
-	// else use e.point for startPoint
-	if(!this.startPoint)
-	this.startPoint = e.point;
+    // check if there is a hoverpoint
+    // else use e.point for startPoint
+    if (!this.startPoint) this.startPoint = e.point;
   }
 
   onMouseDrag(e) {
-    this.path.remove();
+    this.path.remove(); // remove the hover preview
 
-	// remove the hover preview
-	this.hoverPreview.remove();
+    this.hoverPreview.remove(); // find what's under the cursor
 
-	// find what's under the cursor
-	this.hitResult = this._updateHitResult(e);
+    this.hitResult = this._updateHitResult(e); // snap to point if option/ alt or command/ control
 
-	// snap to point if option/ alt or command/ control
-	if( (e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option ) && this.hitResult.type === 'segment') {
-		this.endPoint = {
-			x: this.hitResult.segment.point.x,
-			y: this.hitResult.segment.point.y
-		};
+    if ((e.modifiers.alt || e.modifiers.command || e.modifiers.control || e.modifiers.option) && this.hitResult.type === 'segment') {
+      this.endPoint = {
+        x: this.hitResult.segment.point.x,
+        y: this.hitResult.segment.point.y
+      };
+      this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+      this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
+      this.hoverPreview.strokeWidth = 1.5; // display red when deleting line by dragging it to start point
 
-		this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5/this.paper.view.zoom);
-		this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
-		this.hoverPreview.strokeWidth = 1.5;
-		
-		// display red when deleting line by dragging it to start point
-		this.hoverPreview.fillColor = 
-		(this.endPoint.x===this.startPoint.x && this.endPoint.y===this.startPoint.y)?
-		'rgba(150,50,50,0.5)':'rgba(50,50,255,0.5)';
+      this.hoverPreview.fillColor = this.endPoint.x === this.startPoint.x && this.endPoint.y === this.startPoint.y ? 'rgba(150,50,50,0.5)' : 'rgba(50,50,255,0.5)';
+    } else {
+      // default to cursor position
+      this.endPoint = e.point;
+    } // straight line
 
-	}else{ // default to cursor position
-		this.endPoint = e.point;
-	}
 
-	// straight line
-	if(e.modifiers.shift){
-		const dy = Math.abs(this.startPoint.y - e.point.y);
-		const dx = Math.abs(this.startPoint.x - e.point.x);
+    if (e.modifiers.shift) {
+      const dy = Math.abs(this.startPoint.y - e.point.y);
+      const dx = Math.abs(this.startPoint.x - e.point.x); // diagnol
 
-		// diagnol
-		if(dy && dx && (dy/dx)>0.5 && (dx/dy)>0.5){
-			const diff = {
-				x: this.endPoint.x-this.startPoint.x,
-				y: this.endPoint.y-this.startPoint.y
-			}
-			this.endPoint = {
-				x: this.startPoint.x + (dy+dx)/2 * diff.x/Math.abs(diff.x),
-				y: this.startPoint.y + (dy+dx)/2 * diff.y/Math.abs(diff.y)
-			}
-		}else if(dy>dx) // straight vertical
-			this.endPoint.x = this.startPoint.x;
-		else // straight horizontal
-			this.endPoint.y = this.startPoint.y;
+      if (dy && dx && dy / dx > 0.5 && dx / dy > 0.5) {
+        const diff = {
+          x: this.endPoint.x - this.startPoint.x,
+          y: this.endPoint.y - this.startPoint.y
+        };
+        this.endPoint = {
+          x: this.startPoint.x + (dy + dx) / 2 * diff.x / Math.abs(diff.x),
+          y: this.startPoint.y + (dy + dx) / 2 * diff.y / Math.abs(diff.y)
+        };
+      } else if (dy > dx) // straight vertical
+        this.endPoint.x = this.startPoint.x;else // straight horizontal
+        this.endPoint.y = this.startPoint.y;
+    }
 
-	}
-	this.hoverPreview.data.wickType = 'gui';
-
+    this.hoverPreview.data.wickType = 'gui';
     this.path = new paper.Path.Line(this.startPoint, this.endPoint);
     this.path.strokeCap = 'round';
     this.path.strokeColor = this.getSetting('strokeColor').rgba;
@@ -60452,18 +60433,19 @@ Wick.Tools.Line = class extends Wick.Tool {
   }
 
   onMouseUp(e) {
-	this.hoverPreview.remove();
+    this.hoverPreview.remove();
     this.path.remove();
-	if(this.endPoint.x!==this.startPoint.x || this.endPoint.y!==this.startPoint.y){
-		this.addPathToProject(this.path);
-		this.fireEvent({
-		eventName: 'canvasModified',
-		actionName: 'line'
-		});
-	}
-  }
 
-  // todo: clean this function -H.A.
+    if (this.endPoint.x !== this.startPoint.x || this.endPoint.y !== this.startPoint.y) {
+      this.addPathToProject(this.path);
+      this.fireEvent({
+        eventName: 'canvasModified',
+        actionName: 'line'
+      });
+    }
+  } // todo: clean this function -H.A.
+
+
   _updateHitResult(e) {
     var newHitResult = this.paper.project.hitTest(e.point, {
       fill: false,
@@ -60476,7 +60458,6 @@ Wick.Tools.Line = class extends Wick.Tool {
         return result.item !== this.hoverPreview && !result.item.data.isBorder;
       }
     });
-
     if (!newHitResult) newHitResult = new this.paper.HitResult();
 
     if (newHitResult.item && !newHitResult.item.data.isSelectionBoxGUI) {

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -57837,7 +57837,6 @@ Wick.Clip = class extends Wick.Tickable {
 
 	  if(isNaN(t1) || isNaN(t2)){
 		let pointY = c[1] + Math.abs(dx)*(dy2/Math.abs(dx2)); //a[1] + (dy1) * t1;
-		// if(pointY < Math.max(a[1],b[1]) && pointY > Math.min(a[1],b[1]))
 		if(((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))
 			&& pointY === Math.max(Math.min(a[1],pointY),b[1]))
 		intersections.push({x: a[0],y: pointY});

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -57797,6 +57797,7 @@ Wick.Clip = class extends Wick.Tickable {
       return null;
     }
 
+
     let c1 = bounds1.center;
     let c2 = bounds2.center; // clockwise arrays of points in format [[x1, y1], [x2, y2], ...]
 
@@ -57834,72 +57835,53 @@ Wick.Clip = class extends Wick.Tickable {
       let t2 = (dy - dy1*dx / dx1) / (dy1*dx2 / dx1 - dy2);
       let t1 = (dx + dx2*t2 ) / dx1;
 
+	  if(isNaN(t1) || isNaN(t2)){
+		let pointY = c[1] + Math.abs(dx)*(dy2/Math.abs(dx2)); //a[1] + (dy1) * t1;
+		// if(pointY < Math.max(a[1],b[1]) && pointY > Math.min(a[1],b[1]))
+		if(
+			true ||
+			((dx>0 && d[0]<a[0]) || (dx<0 && d[0]>a[0]))
+			&&
+			pointY < Math.max(a[1],b[1])
+			&&
+			pointY > Math.min(a[1],b[1])
+		)
+		intersections.push({
+          x: a[0],
+          y: pointY
+        });
+	  }
+
       if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
-		// window.intersectingRN.unshift(true);
         intersections.push({
           x: a[0] + (dx1) * t1,
           y: a[1] + (dy1) * t1
         });
-      }else{
-		// todo delete me
-		if(isNaN(t1) && i2 === 3){
-			
-			window.intersectingRN.unshift(" (i1 "+i1+" • i2"+i2+") \n");
-		}
-		if(isNaN(t2) && i2 === 3){
-			
-			// window.intersectingRN.unshift("t2_"+i1+","+i2);
-			window.intersectingRN.unshift(" dx2: "+Math.round(dx2)+" ");
-			window.intersectingRN.unshift(" dx1: "+Math.round(dx1)+" ");
-			window.intersectingRN.unshift(" dx: "+Math.round(dx)+" ");
-		}
-	}
-	// window.intersectingRN.unshift(`${dx2.toFixed(1)} | ${c[0]} | ${d[0]}`);
-
-	  // vertical CD line intersection
-	  if(isNaN(t1) && isNaN(t2)){
-		// dx1 = 0 vertical shape
-		if(dx > 0 && dx1 === 0 && dx < Math.abs(dx2)){
-			// check collision
+      }
+	
 			/*
 
 
 
-                ____   ___    ________     _____         __________ 
-			   //  /  /  /   //  ____/    //   /        //   ___  /
-			  //  /__/  /   //  /__,     //   /        //   /__/ /
-		     //  ___   |   //  ____/    //   /        //   _____/  
-		    //  /  /  /   //  /____    //   /____    //   /      
-		   //__/  /__/   //_______/   //________/   //___/          ME
-		   . . .
-		   save yourself too.  . ..…… RUN BEFORE ITS TOO LATE FOR YOU
+           ____   ___    ________     _____         __________ 
+		  //  /  /  /   //  ____/    //   /        //   ___  /
+		 //  /__/  /   //  /__,     //   /        //   /__/ /
+    	//  ___   |   //  ____/    //   /        //   _____/  
+	   //  /  /  /   //  /____    //   /____    //   /      
+	  //__/  /__/   //_______/   //________/   //___/      ME
+	. . .
+		   save yourself too . . .
+		   .  . ..…… RUN BEFORE ITS TOO LATE FOR YOU
 		   
 		   
 
 
-			*/
-			let pointY = c[1] + (dy2/Math.abs(dx2))*(dx2*Math.abs(dx)/dx2);
-			// if(pointY < Math.max(a[1],b[1]) && pointY > Math.min(a[1],b[1]))
-			intersections.push({
-				x: a[0],
-				y: pointY
-			})
-			
-		}
+		*/
 
 
 
-
-	}
-
-
-
-	  if(window.intersectionSegmentsLines1.length>8){
-		window.intersectionSegmentsLines1.pop();
-		window.intersectionSegmentsLines2.pop();
+	  if(window.intersectingRN.length>8)
 		window.intersectingRN.pop();
-	  }
-
 
       let APointingToB = t1 > 1;
       let BPointingToA = t2 > 1;

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -57824,18 +57824,86 @@ Wick.Clip = class extends Wick.Tickable {
       //t2((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y)) = c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x)
       //t2 = (c.y - a.y - (b.y - a.y)*(c.x - a.x)/(b.x - a.x))  /  ((b.y - a.y)(d.x - c.x)/(b.x - a.x) - (d.y - c.y))
 
-      let t2 = (c[1] - a[1] - (b[1] - a[1]) * (c[0] - a[0]) / (b[0] - a[0])) / ((b[1] - a[1]) * (d[0] - c[0]) / (b[0] - a[0]) - d[1] + c[1]);
-      let t1 = (c[0] + (d[0] - c[0]) * t2 - a[0]) / (b[0] - a[0]);
+	  let dx1 = b[0] - a[0],
+		  dy1 = b[1] - a[1],
+		  dx2 = d[0] - c[0],
+		  dy2 = d[1] - c[1],
+		  dx  = c[0] - a[0],
+		  dy  = c[1] - a[1]
+
+      let t2 = (dy - dy1*dx / dx1) / (dy1*dx2 / dx1 - dy2);
+      let t1 = (dx + dx2*t2 ) / dx1;
 
       if (0 <= t1 && t1 <= 1 && 0 <= t2 && t2 <= 1) {
+		// window.intersectingRN.unshift(true);
         intersections.push({
-          x: a[0] + (b[0] - a[0]) * t1,
-          y: a[1] + (b[1] - a[1]) * t1
+          x: a[0] + (dx1) * t1,
+          y: a[1] + (dy1) * t1
         });
-      }
+      }else{
+		// todo delete me
+		if(isNaN(t1) && i2 === 3){
+			
+			window.intersectingRN.unshift(" (i1 "+i1+" • i2"+i2+") \n");
+		}
+		if(isNaN(t2) && i2 === 3){
+			
+			// window.intersectingRN.unshift("t2_"+i1+","+i2);
+			window.intersectingRN.unshift(" dx2: "+Math.round(dx2)+" ");
+			window.intersectingRN.unshift(" dx1: "+Math.round(dx1)+" ");
+			window.intersectingRN.unshift(" dx: "+Math.round(dx)+" ");
+		}
+	}
+	// window.intersectingRN.unshift(`${dx2.toFixed(1)} | ${c[0]} | ${d[0]}`);
+
+	  // vertical CD line intersection
+	  if(isNaN(t1) && isNaN(t2)){
+		// dx1 = 0 vertical shape
+		if(dx > 0 && dx1 === 0 && dx < Math.abs(dx2)){
+			// check collision
+			/*
+
+
+
+                ____   ___    ________     _____         __________ 
+			   //  /  /  /   //  ____/    //   /        //   ___  /
+			  //  /__/  /   //  /__,     //   /        //   /__/ /
+		     //  ___   |   //  ____/    //   /        //   _____/  
+		    //  /  /  /   //  /____    //   /____    //   /      
+		   //__/  /__/   //_______/   //________/   //___/          ME
+		   . . .
+		   save yourself too.  . ..…… RUN BEFORE ITS TOO LATE FOR YOU
+		   
+		   
+
+
+			*/
+			let pointY = c[1] + (dy2/Math.abs(dx2))*(dx2*Math.abs(dx)/dx2);
+			// if(pointY < Math.max(a[1],b[1]) && pointY > Math.min(a[1],b[1]))
+			intersections.push({
+				x: a[0],
+				y: pointY
+			})
+			
+		}
+
+
+
+
+	}
+
+
+
+	  if(window.intersectionSegmentsLines1.length>8){
+		window.intersectionSegmentsLines1.pop();
+		window.intersectionSegmentsLines2.pop();
+		window.intersectingRN.pop();
+	  }
+
 
       let APointingToB = t1 > 1;
       let BPointingToA = t2 > 1;
+	//   console.info(`t1 ${t1}\nt2 ${t2}`);
 
       if (BPointingToA && !APointingToB) {
         // Advance B


### PR DESCRIPTION
Doesn't 100% fix the convex collision but does improve it. I realized there might be issues with the actual algorithm used that we might want to look through to fix the issue with collision between flat edges of shapes (convex collision). 

Original hits convex code written by nick, using this algo:
https://www.bowdoin.edu/~ltoma/teaching/cs3250-CompGeom/spring17/Lectures/cg-convexintersection.pdf

See commit https://github.com/Candlestickers/Candlestick/commit/a588e13f0a50d0843dd80eba6087876f82055256
See issue https://github.com/Candlestickers/Candlestick/issues/31

Test file (created by BaronAWC, edited slightly by me): [HitsBug.zip](https://github.com/user-attachments/files/21815920/HitsBug.zip)