### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+**Describe the Bug**
 A clear and concise description of what the bug is.
 
 **Editor Version**
@@ -16,11 +16,11 @@ Is this bug reproducible in Wick Editor [1.19.3](https://www.wickeditor.com/edit
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
-**Expected behavior**
+**Expected Behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
@@ -31,7 +31,7 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g. Chrome, Firefox]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+**Mobile (please complete the following information):**
  - Device: [e.g. iPhone 6]
  - OS: [e.g. iOS 8.1]
  - Browser [e.g. Safari]
@@ -39,5 +39,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Do you have a suggested solution to this issue? (ex. has another program fixed this bug a certain way? Are you familiar with where in the code base someone would need to fix this issue?)**
 
-**Additional context**
+**Additional Context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-**Describe the Bug**
+**Describe the bug**
 A clear and concise description of what the bug is.
 
-**Editor Version**
+**Editor version**
 Is this bug reproducible in Wick Editor [1.19.3](https://www.wickeditor.com/editor/)/[1.19.4](https://www.wickeditor.com/test/) or only Candlestick?
 
-**To Reproduce**
+**To reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '...'
 3. Scroll down to '...'
 4. See error
 
-**Expected Behavior**
+**Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
@@ -39,5 +39,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Do you have a suggested solution to this issue? (ex. has another program fixed this bug a certain way? Are you familiar with where in the code base someone would need to fix this issue?)**
 
-**Additional Context**
+**Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Bug Report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
@@ -9,6 +9,9 @@ assignees: ''
 
 **Describe the bug**
 A clear and concise description of what the bug is.
+
+**Editor Version**
+Is this bug reproducible in Wick Editor [1.19.3](https://www.wickeditor.com/editor/)/[1.19.4](https://www.wickeditor.com/test/) or only Candlestick?
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -24,14 +27,14 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. Windows, MacOS]
+ - OS: [e.g. Windows, macOS]
  - Browser [e.g. Chrome, Firefox]
  - Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
+ - Device: [e.g. iPhone 6]
+ - OS: [e.g. iOS 8.1]
+ - Browser [e.g. Safari]
  - Version [e.g. 22]
 
 **Do you have a suggested solution to this issue? (ex. has another program fixed this bug a certain way? Are you familiar with where in the code base someone would need to fix this issue?)**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,9 +10,6 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**Editor version**
-Is this bug reproducible in Wick Editor [1.19.3](https://www.wickeditor.com/editor/)/[1.19.4](https://www.wickeditor.com/test/) or only Candlestick?
-
 **To reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
@@ -26,15 +23,13 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows, macOS]
- - Browser [e.g. Chrome, Firefox]
- - Version [e.g. 22]
+**Editor version**
+Is this bug reproducible in Wick Editor [1.19.3](https://www.wickeditor.com/editor/)/[1.19.4](https://www.wickeditor.com/test/) or only Candlestick?
 
-**Mobile (please complete the following information):**
- - Device: [e.g. iPhone 6]
- - OS: [e.g. iOS 8.1]
- - Browser [e.g. Safari]
+**Device**
+ - Hardware [e.g. MacBook Air M1]
+ - OS [e.g. macOS 15.6]
+ - Browser [e.g. Chrome, Firefox]
  - Version [e.g. 22]
 
 **Do you have a suggested solution to this issue? (ex. has another program fixed this bug a certain way? Are you familiar with where in the code base someone would need to fix this issue?)**

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -13,5 +13,5 @@ Choose either "addition" or "edit". If documentation already exists for this con
 **What concept, or code, does this relate to?**
 Add a code sample, or link to a reference item.
 
-**Additional context**
+**Additional Context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -13,5 +13,5 @@ Choose either "addition" or "edit". If documentation already exists for this con
 **What concept, or code, does this relate to?**
 Add a code sample, or link to a reference item.
 
-**Additional Context**
+**Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Feature Request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement


### PR DESCRIPTION
very minor consistency changes because they bother me lol, plus a new section in the bug report to ask whether a bug is also in wick 1.19.3/4 or only candlestick.

bug-report using a dash and the other 2 using underscores is going to haunt me for the rest of my life but i don't feel like breaking anything right now