### PR TITLE
Fix file inputs on mobile iOS

### DIFF
--- a/src/Editor/Modals/MobileMenu/MobileMenu.jsx
+++ b/src/Editor/Modals/MobileMenu/MobileMenu.jsx
@@ -33,7 +33,7 @@ class MobileMenu extends Component {
     };
 
     let items = [{text: "new", icon: "create-white", action: this.props.openNewProjectConfirmation},
-        {text: "open", icon: "load-white", action: this.props.openProjectFileDialog},
+        {text: "open", icon: "load-white", action: this.props.openProjectFileDialog, useClickEvent: true},
         {text: "export", icon: "export", action: () => this.props.openModal('ExportOptions')},
         {text: "settings", icon: "gear-white", action: () => this.props.openModal('SettingsModal')},
         {text: "about", icon: "mascotmarkwhite", action: () => this.props.openModal('EditorInfo')}];
@@ -43,8 +43,8 @@ class MobileMenu extends Component {
         {...modalProps}
         className="mobile-menu-mobile-body">
             <div className="mobile-menu-options-container">
-                {items.map(({text, icon, action}) => 
-                <ActionButton key={text} className="mobile-menu-option" buttonClassName="no-bg mobile-menu-button" iconClassName="mobile-menu-icon" action={action} text={text} icon={icon}/>)}
+                {items.map(({text, icon, action, useClickEvent}) => 
+                <ActionButton key={text} className="mobile-menu-option" buttonClassName="no-bg mobile-menu-button" iconClassName="mobile-menu-icon" action={action} text={text} icon={icon} useClickEvent={useClickEvent}/>)}
             </div>
             <div className="mobile-menu-close">
                 <ActionButton icon="cancel-white" iconClassName="mobile-menu-close-icon" buttonClassName="no-bg" action={this.props.toggle} color="gray"/>

--- a/src/Editor/Panels/AssetLibrary/AssetLibrary.jsx
+++ b/src/Editor/Panels/AssetLibrary/AssetLibrary.jsx
@@ -110,6 +110,7 @@ class AssetLibrary extends Component {
           <ActionButton
             color="upload"
             action={this.openFileDialog}
+            useClickEvent={true}
             id="button-asset-upload"
             icon="upload"
             tooltip="Upload Assets" />

--- a/src/Editor/Panels/MenuBar/MenuBar.jsx
+++ b/src/Editor/Panels/MenuBar/MenuBar.jsx
@@ -58,6 +58,7 @@ class MenuBar extends Component {
           <MenuBarButton
             text="open"
             action={this.props.openProjectFileDialog}
+            useClickEvent={true}
           />
 
           <MenuBarButton

--- a/src/Editor/Panels/MenuBar/MenuBarButton/MenuBarButton.jsx
+++ b/src/Editor/Panels/MenuBar/MenuBarButton/MenuBarButton.jsx
@@ -28,6 +28,7 @@ class MenuBarButton extends Component {
         <ActionButton
           text={this.props.text}
           action={this.props.action}
+          useClickEvent={this.props.useClickEvent}
           color={'menu ' + (this.props.color ? this.props.color : '')}>
         </ActionButton>
       </div>

--- a/src/Editor/Panels/MobileContainer/MobileAssetLibrary/MobileAssetLibrary.jsx
+++ b/src/Editor/Panels/MobileContainer/MobileAssetLibrary/MobileAssetLibrary.jsx
@@ -123,6 +123,7 @@ class MobileAssetLibrary extends Component {
           <ActionButton
             color="inspector"
             action={this.openFileDialog}
+            useClickEvent={true}
             id="button-asset-upload"
             icon="upload-dark"
             iconClassName="mobile-asset-library-icon"

--- a/src/Editor/Util/ActionButton/ActionButton.jsx
+++ b/src/Editor/Util/ActionButton/ActionButton.jsx
@@ -94,6 +94,7 @@ export default function ActionButton (props) {
         className={finalColorClassName}
         type="button"
         secondaryAction={props.secondaryAction}
+        useClickEvent={props.useClickEvent}
         onClick={runAction}
         onTouch={runAction}>
           {renderContent()}

--- a/src/Editor/Util/WickInput/WickButton/WickButton.jsx
+++ b/src/Editor/Util/WickInput/WickButton/WickButton.jsx
@@ -39,11 +39,12 @@ export default function WickButton(props) {
     }
   }
 
+  const useTouchStart = isMobile && !props.useClickEvent;
   return (
     <button
       {...props.buttonProps}
-      onTouchStart={isMobile ? handleClick : undefined}
-      onClick={isMobile ? undefined : handleClick}
+      onTouchStart={useTouchStart ? handleClick : undefined}
+      onClick={useTouchStart ? undefined : handleClick}
       className={classNames("wick-button ", props.className)}>
       {props.children}
     </button>

--- a/src/files/filehandler.js
+++ b/src/files/filehandler.js
@@ -98,12 +98,14 @@ export default function initializeDefaultFileHandlers() {
     window.createFileInput = (args) => {
       let onChange = args.onChange || (() => { console.log("Updating Chosen Element") });
       let input = document.createElement('input');
+      input.className = "wick-editor-hidden-file-input";
       input.type = 'file';
       input.style.display = 'none';
-      args.accept && (input.accept = args.accept);
-      input.onchange = onChange;
+      let isIOS = navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i);
+      args.accept && !isIOS && (input.accept = args.accept);
       args.multiple && (input.multiple = "multiple");
-      input.className = "wick-editor-hidden-file-input";
+      document.body.appendChild(input);
+      input.addEventListener('change', onChange);
 
       function clickInput() {
         input.click();


### PR DESCRIPTION
Importing a project or assets now work on mobile iOS. Required file types are not supported. Tested on [test page](https://stickmanred.github.io/wick-editor/test-import/), works on mobile with no behavior change on other devices.