### PR TITLE
fix: code editor resizing to default after closing and reopening it

### DIFF
--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -490,8 +490,8 @@ class Editor extends EditorCore {
     }
 
     getDefaultCodeEditorProperties = () => {
-        var width = window.innerWidth / 2;
-        var height = window.innerHeight / 2;
+        var width = Math.round(window.innerWidth  * 0.75);
+        var height = Math.round(window.innerHeight * 0.85);
         return (
             {
                 width: width,

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -492,8 +492,8 @@ class Editor extends EditorCore {
     getDefaultCodeEditorProperties = () => {
         return (
             {
-                width: window.innerWidth,
-                height: window.innerHeight,
+                width: window.innerWidth - 510, // magic number: outliner/inspector width
+                height: window.innerHeight - 260, // magic number: toolbar/timeline height
                 x: 0,
                 y: 40, // magic number: toolbar height (not including the menubar, since for some reason y=0 is at the bottom of the menubar?)
                 minWidth: 400,

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -490,12 +490,10 @@ class Editor extends EditorCore {
     }
 
     getDefaultCodeEditorProperties = () => {
-        var width = Math.round(window.innerWidth  * 0.75);
-        var height = Math.round(window.innerHeight * 0.85);
         return (
             {
-                width: width,
-                height: height,
+                width: window.innerWidth,
+                height: window.innerHeight,
                 x: 0,
                 y: 40, // magic number: toolbar height (not including the menubar, since for some reason y=0 is at the bottom of the menubar?)
                 minWidth: 400,

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -496,8 +496,8 @@ class Editor extends EditorCore {
             {
                 width: width,
                 height: height,
-                x: window.innerWidth / 2 - width / 2,
-                y: window.innerHeight / 2 - height / 2,
+                x: 0,
+                y: 40, // magic number: toolbar height (not including the menubar, since for some reason y=0 is at the bottom of the menubar?)
                 minWidth: 400,
                 minHeight: 250,
                 consoleHeight: 100,

--- a/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
+++ b/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
@@ -346,7 +346,9 @@ export default function WickCodeEditor(props) {
     )
   }
 
-  const defaultAceCodeProps = {x: 0,y: 0,
+  const defaultAceCodeProps = {
+    x: props.codeEditorWindowProperties.x,
+    y: props.codeEditorWindowProperties.y,
     width: props.codeEditorWindowProperties.width,
     height: props.codeEditorWindowProperties.height,
   };

--- a/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
+++ b/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
@@ -346,13 +346,6 @@ export default function WickCodeEditor(props) {
     )
   }
 
-  const defaultAceCodeProps = {
-    x: props.codeEditorWindowProperties.x,
-    y: props.codeEditorWindowProperties.y,
-    width: props.codeEditorWindowProperties.width,
-    height: props.codeEditorWindowProperties.height,
-  };
-
   if (props.renderSize === 'small') {
     return (
       <Rnd
@@ -395,7 +388,7 @@ export default function WickCodeEditor(props) {
         minHeight={props.codeEditorWindowProperties.minHeight}
         onResizeStop={onResizeHandler}
         onDragStop={onDragHandler}
-        default={defaultAceCodeProps}
+        default={props.codeEditorWindowProperties}
       >
 
         <div className="wick-code-editor-drag-handle">

--- a/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
+++ b/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
@@ -347,8 +347,8 @@ export default function WickCodeEditor(props) {
   }
 
   const defaultAceCodeProps = {x: 0,y: 0,
-    width: Math.round(window.innerWidth  *0.75),
-    height: Math.round(window.innerHeight*0.85),
+    width: props.codeEditorWindowProperties.width,
+    height: props.codeEditorWindowProperties.height,
   };
 
   if (props.renderSize === 'small') {


### PR DESCRIPTION
This pull request fixes issue: https://github.com/Candlestickers/Candlestick/issues/85