### PR TITLE
fix: Breaking apart parent clip makes child clips undeletable

### DIFF
--- a/engine/src/base/Frame.js
+++ b/engine/src/base/Frame.js
@@ -409,6 +409,7 @@ Wick.Frame = class extends Wick.Tickable {
         }
 
         this.addChild(clip);
+        clip._willBeRemoved = false; // Fixes a bug where breaking apart a parent clip causes child clips to be undeletable
 
         // Pre-render the clip's frames
         // (this fixes an issue where clips created from ClipAssets would be "missing" frames)


### PR DESCRIPTION
Fixes [clip bug](https://forum.wickeditor.com/t/scratch-like-cursor/18102/52)

The bug was caused by `_willBeRemoved` being set to `true` by `clip.remove()` in `Wick.Frame.addClip`. Bugfix tested through console on Candlestick.

Requires engine build to test