### PR TITLE
fix: Copying a gradient path causes bugs

### DIFF
--- a/engine/src/base/Path.js
+++ b/engine/src/base/Path.js
@@ -88,6 +88,10 @@ Wick.Path = class extends Wick.Base {
 
         data.json = this.json;
         delete data.json[1].data;
+        if (typeof data.json[0] !== "string") {
+            // This is a gradient-colored path
+            delete data.json[1][1].data;
+        }
 
         // optimization: replace dataurls with asset uuids
         if (data.json[0] === 'Raster' && data.json[1].source.startsWith('data:')) {


### PR DESCRIPTION
Fixes [Gradient Issue](https://discord.com/channels/1406876763920797717/1466907270888689827)

In path serialization of a gradient, its `wickUUID` doesn't get deleted, which causes its copies to share the same UUID. Tested through console on Candlestick. Requires engine build to test