### PR TITLE
fix: Objects keep moving when Shift+Direction pressed

### DIFF
--- a/src/Editor/hotKeyMap.js
+++ b/src/Editor/hotKeyMap.js
@@ -567,6 +567,8 @@ class HotKeyInterface extends Object {
       // Start the repeat timers if this hotkey is repeatable
       var options = this.keyMap[name];
       if(options.repeatable) {
+        clearInterval(this.repeatKeyInterval);
+        clearTimeout(this.repeatKeyTimeout);
         this.repeatKeyTimeout = setTimeout(() => {
           this.repeatKeyInterval = setInterval(() => {
             fn();


### PR DESCRIPTION
The bug was reported on [the forums](https://forum.wickeditor.com/t/objects-can-continue-moving-on-their-own-after-pressing-shift-arrow-keys/24022). This fix clears the previous key repeat intervals (if any) before setting a new repeat.