### PR TITLE
fix: Detailed path cursor doesn't work on paths with holes

### DIFF
--- a/engine/src/tools/PathCursor.js
+++ b/engine/src/tools/PathCursor.js
@@ -270,7 +270,12 @@ Wick.Tools.PathCursor = class extends Wick.Tool {
         if(!newHitResult) newHitResult = new this.paper.HitResult();
 
         if (this.detailedEditing !== null) {
-            if (this._getWickUUID(newHitResult.item) !== this._getWickUUID(this.detailedEditing)) {
+            // Bugfix: newHitResult.item might be inside a CompoundPath
+            var targetItem = newHitResult.item;
+            if (targetItem && targetItem.parent.className === 'CompoundPath') {
+                targetItem = targetItem.parent;
+            }
+            if (this._getWickUUID(targetItem) !== this._getWickUUID(this.detailedEditing)) {
                 // Hits an item, but not the one currently in detail edit - handle as a click with no hit.
                 return new this.paper.HitResult();
             }


### PR DESCRIPTION
Reported on [the forums](https://forum.wickeditor.com/t/path-cursor-problems/19308). In [this block of code](https://github.com/Wicklets/wick-editor/blob/f34f0d9512d7165e74c1910ea1aba9173ab8dec2/engine/src/tools/PathCursor.js#L273-L275), the hit test only continues if the hit item is the path currently in detailed editing. However, for CompoundPaths, `newHitResult.item` will be a child path of `detailedEditing`, so the hit test returns nothing and the Path Cursor won't work. This bugfix handles that case.

Requires an engine build to test.