### PR TITLE
Auto-create frame when creating a text object

### DIFF
--- a/engine/src/tools/Text.js
+++ b/engine/src/tools/Text.js
@@ -88,7 +88,11 @@ Wick.Tools.Text = class extends Wick.Tool {
             text.content = 'Text';
             text.fontSize = 24;
 
-            var wickText = new Wick.Path({json: text.exportJSON({asString:false})})
+            var wickText = new Wick.Path({json: text.exportJSON({asString:false})});
+            if(!this.project.activeFrame) {
+                // Automatically add a frame is there isn't one
+                this.project.insertBlankFrame();
+            }
             this.project.activeFrame.addPath(wickText);
 
             this.project.view.render();


### PR DESCRIPTION
Most tools automatically create a blank frame if the playhead is in a position without a frame, but the text tool didn't do this.

This PR adds this behavior to the text tool.