### PR TITLE
Fix erasing compound paths that have a stroke

### DIFF
--- a/engine/src/view/paper-ext/Layer.erase.js
+++ b/engine/src/view/paper-ext/Layer.erase.js
@@ -100,16 +100,17 @@
 
     function eraseStroke (path, eraserPath) {
         if(path.children) {
-            // recursive case: ungroup compound path of strokes
+            // ungroup compound path of strokes because Paper cannot erase compound strokes
             var children = [];
             path.children.forEach(function (child) {
                 child.data = {};
                 children.push(child);
                 child.name = null;
             });
-            // call eraser for each child individually
+            // move each child up, then erase individually
             children.forEach(function (child) {
                 child.insertAbove(path);
+                child.fillColor = null;
                 eraseStroke(child, eraserPath);
             });
         } else {

--- a/engine/src/view/paper-ext/Layer.erase.js
+++ b/engine/src/view/paper-ext/Layer.erase.js
@@ -110,7 +110,7 @@
             // move each child up, then erase individually
             children.forEach(function (child) {
                 child.insertAbove(path);
-                child.fillColor = null;
+                child.style = path.style;
                 eraseStroke(child, eraserPath);
             });
         } else {

--- a/engine/src/view/paper-ext/Layer.erase.js
+++ b/engine/src/view/paper-ext/Layer.erase.js
@@ -99,26 +99,42 @@
     }
 
     function eraseStroke (path, eraserPath) {
-        var res = path.subtract(eraserPath, {
-            insert: false,
-            trace: false,
-        });
-        if(res.children) {
-            // Since the path is only strokes, it's trivial to split it into individual paths
+        if(path.children) {
+            // recursive case: ungroup compound path of strokes
             var children = [];
-            res.children.forEach(function (child) {
+            path.children.forEach(function (child) {
                 child.data = {};
                 children.push(child);
                 child.name = null;
             });
+            // call eraser for each child individually
             children.forEach(function (child) {
                 child.insertAbove(path);
+                eraseStroke(child, eraserPath);
             });
-            res.remove();
         } else {
-            res.remove();
-            if(res.segments.length > 0)
-                res.insertAbove(path);
+            // base case: erasing singular stroke
+            var res = path.subtract(eraserPath, {
+                insert: false,
+                trace: false,
+            });
+            if(res.children) {
+                // Since the path is only strokes, it's trivial to split it into individual paths
+                var children = [];
+                res.children.forEach(function (child) {
+                    child.data = {};
+                    children.push(child);
+                    child.name = null;
+                });
+                children.forEach(function (child) {
+                    child.insertAbove(path);
+                });
+                res.remove();
+            } else {
+                res.remove();
+                if(res.segments.length > 0)
+                    res.insertAbove(path);
+            }
         }
         path.remove();
     }


### PR DESCRIPTION
Paper has a bug with subtracting paths that results in CompoundPaths with a non-null stroke breaking the eraser. This fixes the issue by decomposing the stroke into its individual parts before erasing each one.