### PR TITLE
Re-add error message when fill bucket fails

### DIFF
--- a/engine/src/tools/FillBucket.js
+++ b/engine/src/tools/FillBucket.js
@@ -121,6 +121,9 @@ Wick.Tools.FillBucket = class extends Wick.Tool {
                         this.addPathToProject(path);
                         this.fireEvent({ eventName: 'canvasModified', actionName: 'fillbucket' });
                     }
+                }, onError: (message) => {
+                    this.setCursor('default');
+                    this.project.errorOccured(message);
                 }
             });
         }, 0);


### PR DESCRIPTION
The onError code for using the fill bucket was accidentally removed, so this just adds it back.