### PR TITLE
Make toasts less obstructive

### DIFF
--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -853,12 +853,12 @@ class Editor extends EditorCore {
 
         // Default options for the toast:
         let defaultOptions = {
-            position: "top-right",
+            position: "bottom-right",
             autoClose: 3000,
             hideProgressBar: true,
             closeOnClick: true,
             pauseOnHover: true,
-            draggable: true,
+            draggable: false,
             className: (type + '-toast-background'),
             bodyClassName: (type + '-toast-body'),
             progressClassName: (type + '-toast-progress'),

--- a/src/Editor/_editor.scss
+++ b/src/Editor/_editor.scss
@@ -102,15 +102,16 @@ body {
 // Toasts
 .Toastify__toast {
   font-family: 'Nunito Sans';
-  font-weight: 800;
-  font-size: 24px;
+  font-weight: normal;
+  font-size: 16px;
   border-radius: 3px;
+  min-height: 0;
 }
 
 .Toastify__toast button{
   font-family: 'Nunito Sans';
-  font-weight: 800;
-  font-size: 24px;
+  font-weight: normal;
+  font-size: 16px;
 }
 
 .info-toast-background {

--- a/src/Editor/_editor.scss
+++ b/src/Editor/_editor.scss
@@ -106,6 +106,7 @@ body {
   font-size: 16px;
   border-radius: 3px;
   min-height: 0;
+  padding: 6px;
 }
 
 .Toastify__toast button{


### PR DESCRIPTION
I have shrunk the toasts by quite a bit since that's just what I prefer, but it's definitely up for debate whether I went too small.

I also moved them to the bottom right, because I think it's more acceptable to cover the asset library than the top of the inspector and the save/settings/etc buttons. Additionally, this makes it so that when older toasts at the top slide away, it doesn't awkwardly shove the rest of the toasts up. (It does the weird shoving when a new toast is displayed instead, but I think it's more manageable for my eyes, since at least it catches my attention when there's something new.)

before: (note how the toast is blocking all the buttons in the top right and the name field in the inspector)
<img width="1900" height="1035" alt="image" src="https://github.com/user-attachments/assets/90a5774a-8890-4591-95c3-a422724288d1" />

after:
<img width="1900" height="995" alt="image" src="https://github.com/user-attachments/assets/cdf76f9a-5d16-4834-8358-32530a2ad878" />


Last few things I'm thinking about:
- adding in the progress bar for when a toast auto-closes
- speeding up the open/close animation
- Making all toasts auto-close after the same amount of time (right now it seems like toasts can be 3, 5, or 7 seconds)