### PR TITLE
Fix erasing first vertex of closed path

### DIFF
--- a/engine/src/view/paper-ext/Layer.erase.js
+++ b/engine/src/view/paper-ext/Layer.erase.js
@@ -115,6 +115,16 @@
             });
         } else {
             // base case: erasing singular stroke
+            if (path instanceof paper.Path && path.closed && eraserPath.contains(path.firstSegment.point)) {
+                // Fixes bug with paper.js path subtract
+                // If eraserPath contains the first segment of a closed path, convert to an open path
+                var start = path.firstSegment,
+                    end = start.clone();
+                start.handleIn = [0,0];
+                end.handleOut = [0,0];
+                path.addSegment(end);
+                path.closed = false;
+            }
             var res = path.subtract(eraserPath, {
                 insert: false,
                 trace: false,


### PR DESCRIPTION
This should resolve issue #128. Paper.js has a bug with subtracting a path if it contains the first vertex of a closed path. But because the first vertex will be erased anyway, we can open the path at that vertex without affecting the result.