### PR TITLE
Fix playhead when editing synced, play once, and single frame clips

### DIFF
--- a/engine/src/base/Clip.js
+++ b/engine/src/base/Clip.js
@@ -1628,7 +1628,7 @@ let avgIntersection = {
     _onActive() {
         super._onActive();
 
-        if (this.animationType === 'loop') {
+        if (this.isFocus || this.animationType === 'loop') {
             this.timeline.advance();
         } else if (this.animationType === 'single') {
             this.timeline.playheadPosition = this.singleFrameNumber;
@@ -1642,7 +1642,7 @@ let avgIntersection = {
             }
         } 
         
-        if (this.isSynced) {
+        if (this.isSynced && !this.isFocus) {
             this.timeline.playheadPosition = this.syncFrame;
         }
 


### PR DESCRIPTION
This resolves issue #99. When a clip is being edited, don't sync it with the parent timeline, play it once, or restrict it to a single frame.