### PR TITLE
Fix brush tool and fill bucket bugs on browser zoom

### DIFF
--- a/engine/src/tools/Brush.js
+++ b/engine/src/tools/Brush.js
@@ -378,10 +378,11 @@ Wick.Tools.Brush = class extends Wick.Tool {
             this.paper.view._element.parentElement.appendChild(this.croquisDOMElement);
         }
 
-        // Update croquis element canvas size
-        if(this.croquis.getCanvasWidth() !== this.paper.view._viewSize.width ||
-           this.croquis.getCanvasHeight() !== this.paper.view._viewSize.height) {
-            this.croquis.setCanvasSize(this.paper.view._viewSize.width, this.paper.view._viewSize.height);
+        // use the CSS pixels size (viewSize) rather than trying to predict with device pixels (element.width) — they change when browser zoom ≠ 100% -H.A.
+        var targetW = Math.round(this.paper.view.viewSize.width);
+        var targetH = Math.round(this.paper.view.viewSize.height);
+        if(this.croquis.getCanvasWidth() !== targetW || this.croquis.getCanvasHeight() !== targetH) {
+            this.croquis.setCanvasSize(targetW, targetH);
         }
 
         // Fake brush opacity in croquis by changing the opacity of the croquis canvas

--- a/engine/src/tools/Brush.js
+++ b/engine/src/tools/Brush.js
@@ -379,9 +379,9 @@ Wick.Tools.Brush = class extends Wick.Tool {
         }
 
         // Update croquis element canvas size
-        if(this.croquis.getCanvasWidth() !== this.paper.view._element.width ||
-           this.croquis.getCanvasHeight() !== this.paper.view._element.height) {
-            this.croquis.setCanvasSize(this.paper.view._element.width, this.paper.view._element.height);
+        if(this.croquis.getCanvasWidth() !== this.paper.view._viewSize.width ||
+           this.croquis.getCanvasHeight() !== this.paper.view._viewSize.height) {
+            this.croquis.setCanvasSize(this.paper.view._viewSize.width, this.paper.view._viewSize.height);
         }
 
         // Fake brush opacity in croquis by changing the opacity of the croquis canvas

--- a/engine/src/view/paper-ext/Paper.hole.js
+++ b/engine/src/view/paper-ext/Paper.hole.js
@@ -80,6 +80,8 @@
 
         var rasterResolution = paper.view.resolution * RASTER_BASE_RESOLUTION / window.devicePixelRatio;
         var layerPathsRaster = layerGroup.rasterize(rasterResolution, {insert:false});
+        // Fixes issues with browser zoom
+        var zoomFactor = RASTER_BASE_RESOLUTION * layerPathsRaster.bounds.width / layerPathsRaster.width;
 
         var rasterCanvas = layerPathsRaster.canvas;
         var rasterCtx = rasterCanvas.getContext('2d');
@@ -98,8 +100,8 @@
         layerPathsImageData = rasterCtx.getImageData(0, 0, layerPathsRaster.width, layerPathsRaster.height);
 
         var rasterPosition = layerPathsRaster.bounds.topLeft;
-        var x = (floodFillX - rasterPosition.x) * RASTER_BASE_RESOLUTION;
-        var y = (floodFillY - rasterPosition.y) * RASTER_BASE_RESOLUTION;
+        var x = (floodFillX - rasterPosition.x) * RASTER_BASE_RESOLUTION / zoomFactor;
+        var y = (floodFillY - rasterPosition.y) * RASTER_BASE_RESOLUTION / zoomFactor;
         x = Math.round(x);
         y = Math.round(y);
 
@@ -168,6 +170,8 @@
             }
 
             expandHole(resultHolePath);
+            // Fixes issues with browser zoom
+            resultHolePath.scale(zoomFactor, layerPathsRaster.bounds.topLeft);
             callback(resultHolePath);
         }
         floodFillProcessedImage.src = floodFillCanvas.toDataURL();

--- a/engine/src/view/paper-ext/Path.potrace.js
+++ b/engine/src/view/paper-ext/Path.potrace.js
@@ -34,6 +34,8 @@ paper.Path.inject({
 
         var finalRasterResolution = paper.view.resolution*args.resolution/window.devicePixelRatio;
         var raster = this.rasterize(finalRasterResolution);
+        // Fixes issues with browser zoom
+        var zoomFactor = args.resolution * raster.bounds.width / raster.width;
         raster.remove();
         var rasterDataURL = raster.toDataURL();
 
@@ -51,6 +53,7 @@ paper.Path.inject({
             potracePath.remove();
             potracePath.closed = true;
             potracePath.children[0].closed = true;
+            potracePath.children[0].scale(zoomFactor);
             args.done(potracePath.children[0]);
         }
         img.src = rasterDataURL;


### PR DESCRIPTION
This resolves issue #95 and hopefully issue [Weird UI Glitch](https://discord.com/channels/1406876763920797717/1407064965029826692). For the brush tool, zooming out messes up the size attributes of Wick's `canvas` element: the width/height *attributes* of the canvas become scaled down from the true width and height. But the brush tool's `canvas` uses the smaller width/height attributes as it true size, which is why the brush strokes keep getting cut off.

For the fill bucket, I have no idea why the solution works