### PR TITLE
Fix line snapping to wrong location for segments inside clips

### DIFF
--- a/engine/src/tools/Line.js
+++ b/engine/src/tools/Line.js
@@ -81,12 +81,13 @@ Wick.Tools.Line = class extends Wick.Tool {
 
 		// alt/ option or command/ control to snap to nearby selection
 		if ((this._shouldSnap(e)) && this.hitResult.type === 'segment') {
-			this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+			let globalPoint = this.hitResult.item.parent.localToGlobal(this.hitResult.segment.point);
+			this.hoverPreview = new this.paper.Path.Circle(globalPoint, 5 / this.paper.view.zoom);
 			this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
 			this.hoverPreview.strokeWidth = 1.5;
 			this.hoverPreview.fillColor = 'rgba(150,0,0,0.5)';
 
-			this.startPoint = this.hitResult.segment.point;
+			this.startPoint = globalPoint;
 		} else {
 			this.startPoint = false;
 		}
@@ -135,12 +136,13 @@ Wick.Tools.Line = class extends Wick.Tool {
 
 		// snap to point if option/ alt or command/ control
 		if ((this._shouldSnap(e)) && this.hitResult.type === 'segment') {
+			let globalPoint = this.hitResult.item.parent.localToGlobal(this.hitResult.segment.point);
 			this.endPoint = {
-				x: this.hitResult.segment.point.x,
-				y: this.hitResult.segment.point.y
+				x: globalPoint.x,
+				y: globalPoint.y
 			};
 
-			this.hoverPreview = new this.paper.Path.Circle(this.hitResult.segment.point, 5 / this.paper.view.zoom);
+			this.hoverPreview = new this.paper.Path.Circle(globalPoint, 5 / this.paper.view.zoom);
 			this.hoverPreview.strokeColor = 'rgba(100,100,100,0)';
 			this.hoverPreview.strokeWidth = 1.5;
 


### PR DESCRIPTION
This resolves #98. It uses the `localToGlobal(point)` function to convert from the clip's coordinates to the project's coordinates. Works with nested clips and while editing a clip.