### PR TITLE
Fix outliner expand button tooltip appearing near timeline

### DIFF
--- a/src/Editor/Panels/OutlinerExpandButton/OutlinerExpandButton.jsx
+++ b/src/Editor/Panels/OutlinerExpandButton/OutlinerExpandButton.jsx
@@ -10,17 +10,19 @@ class OutlinerExpandButton extends Component {
   render () {
     
     return (
-      <ActionButton
-      color="tool"
-      isActive={ () => false }
-      id="outliner-toggle"
-      tooltip={this.props.expanded ? "Hide Outliner" : "Show Outliner"}
-      action={this.props.toggleOutliner}
-      tooltipPlace="left"
-      icon="outliner"
-      className="outliner-expand-button"
-      iconClassName={classNames("outliner-toggle-icon", {"outliner-expand-button-closed": !this.props.expanded})}
-      />
+      <div className="outliner-expand-button-container">
+        <ActionButton
+          color="tool"
+          isActive={ () => false }
+          id="outliner-toggle"
+          tooltip={this.props.expanded ? "Hide Outliner" : "Show Outliner"}
+          action={this.props.toggleOutliner}
+          tooltipPlace="left"
+          icon="outliner"
+          className="outliner-expand-button"
+          iconClassName={classNames("outliner-toggle-icon", {"outliner-expand-button-closed": !this.props.expanded})}
+        />
+      </div>
     );
   }
 }

--- a/src/Editor/Panels/OutlinerExpandButton/_outlinerexpandbutton.scss
+++ b/src/Editor/Panels/OutlinerExpandButton/_outlinerexpandbutton.scss
@@ -2,10 +2,14 @@
 
 $button-height: 39px;
 
-.outliner-expand-button {
+.outliner-expand-button-container {
     position: absolute;
     top: 35px;
     right: 0px;
+    height: $button-height;
+    width: $button-height;
+}
+.outliner-expand-button {
     height: $button-height;
     width: $button-height;
     color: $editor-primary-text;


### PR DESCRIPTION
This resolves #71. The tooltip placement depends on where the `<div class="wick-input-container" />` is. So this code moves it to the button