### PR TITLE
Scale line-snapping tolerance with project zoom

### DIFF
--- a/engine/src/tools/Line.js
+++ b/engine/src/tools/Line.js
@@ -252,7 +252,7 @@ Wick.Tools.Line = class extends Wick.Tool {
 			curves: false,
 			segments: true,
 			handles: false,
-			tolerance: 10,
+			tolerance: 20 / this.paper.view.zoom,
 			match: result => {
 				return result.item !== this.hoverPreview && !result.item.data.isBorder;
 			}


### PR DESCRIPTION
Missed an instance of tolerance not scaling with zoom. I think this is it now?

