### PR TITLE
Add ability to export buttons and paths as wick object files

### DIFF
--- a/engine/src/base/Path.js
+++ b/engine/src/base/Path.js
@@ -130,7 +130,7 @@ Wick.Path = class extends Wick.Base {
 
     /**
      * The type of path that this path is. Can be 'path', 'text', or 'image'
-     * @returns {string}
+     * @returns {'text' | 'image' | 'path'}
      */
     get pathType() {
         if (this.view.item instanceof paper.TextItem) {

--- a/src/Editor/EditorCore.jsx
+++ b/src/Editor/EditorCore.jsx
@@ -2055,10 +2055,10 @@ class EditorCore extends Component {
     exportSelectedClip = () => {
         var clip = this.project.selection.getSelectedObject();
         if (!clip) return;
-        if (!(clip instanceof window.Wick.Clip)) return;
+        if (!([window.Wick.Clip, window.Wick.Button, window.Wick.Path].some((o) => clip instanceof o))) return;
 
         window.Wick.WickObjectFile.toWickObjectFile(clip, 'blob', file => {
-            window.saveFileFromWick(file, (clip.identifier || 'object'), '.wickobj');
+            window.saveFileFromWick(file, (clip.identifier || /*Clip::f87f8b7d-62c3-4576-a5bb-61ce87768ce9*/ `${clip.classname}::${clip.uuid}`), '.wickobj');
         });
     }
 

--- a/src/Editor/EditorCore.jsx
+++ b/src/Editor/EditorCore.jsx
@@ -2053,12 +2053,20 @@ class EditorCore extends Component {
     }
 
     exportSelectedClip = () => {
-        var clip = this.project.selection.getSelectedObject();
-        if (!clip) return;
-        if (!([window.Wick.Clip, window.Wick.Button, window.Wick.Path].some((o) => clip instanceof o))) return;
+        var object = this.project.selection.getSelectedObject();
+        if (!object) return;
+        if (!object instanceof Wick.Base || !(object instanceof Wick.Asset))) return;
+        if (object._temporary) return;
+
+        var cname = object.classname;
+        if(cname === 'Path') {
+            var pt = object.path;
+            if(pt === 'path') return; // no need to export paths
+            cname = `Path::${}`; // could be: (some real Rust/C++ codebase has this), Path::image, or Path::text
+        }
 
         window.Wick.WickObjectFile.toWickObjectFile(clip, 'blob', file => {
-            window.saveFileFromWick(file, (clip.identifier || /*Clip::f87f8b7d-62c3-4576-a5bb-61ce87768ce9*/ `${clip.classname}::${clip.uuid}`), '.wickobj');
+            window.saveFileFromWick(file, (clip.identifier || object.identifier !== null ? object.identifier : cname), '.wickobj');
         });
     }
 


### PR DESCRIPTION
This PR adds #139. I don't think I need to clarify any more what and how this change works.