### PR TITLE
Fixed croquis overlay mis-size on zoom ≠ 100% bug

### DIFF
--- a/engine/src/tools/Brush.js
+++ b/engine/src/tools/Brush.js
@@ -378,10 +378,11 @@ Wick.Tools.Brush = class extends Wick.Tool {
             this.paper.view._element.parentElement.appendChild(this.croquisDOMElement);
         }
 
-        // Update croquis element canvas size
-        if(this.croquis.getCanvasWidth() !== this.paper.view._element.width ||
-           this.croquis.getCanvasHeight() !== this.paper.view._element.height) {
-            this.croquis.setCanvasSize(this.paper.view._element.width, this.paper.view._element.height);
+        // use the CSS pixels size (viewSize) rather than trying to predict with device pixels (element.width) — they change when browser zoom ≠ 100% -H.A.
+        var targetW = Math.round(this.paper.view.viewSize.width);
+        var targetH = Math.round(this.paper.view.viewSize.height);
+        if(this.croquis.getCanvasWidth() !== targetW || this.croquis.getCanvasHeight() !== targetH) {
+            this.croquis.setCanvasSize(targetW, targetH);
         }
 
         // Fake brush opacity in croquis by changing the opacity of the croquis canvas


### PR DESCRIPTION
You all remember the famous bug when people try zooming in/ out above or below 100% to make the editor's size more comfortable to work with— but then upon reloading the page, the croquis overlay's size doesn't seem to have adjusted properly so you wound up with something like this when trying to draw with the brush tool as if you're going off of canvas early—
<img width="1440" height="812" alt="image" src="https://github.com/user-attachments/assets/d81b1759-24ee-4984-b2d0-ea9ab85bca9b" />

For a long time we told people to just resize to 100% then reload the window. But now that this bug has been fixed, people can resize the editor to whatever size they're comfortable working with without needing to worry of this bug.