### PR TITLE
Hamzah filenaming

### DIFF
--- a/public/project-converter/project152/WickProject.Exporter.js
+++ b/public/project-converter/project152/WickProject.Exporter.js
@@ -114,7 +114,7 @@ WickProject.Exporter = (function () {
                 
                 var blob1 = new Blob([byteArray], {type: "application/octet-stream"});
 
-                saveAs(blob1, wickProject.name+'-'+timeStamp()+".wick");
+                saveAs(blob1, wickProject.name+".wick");
             });
             return;
         }
@@ -122,7 +122,7 @@ WickProject.Exporter = (function () {
         if(args && args.json) {
             wickProject.getAsJSON(function(JSONProject) {
                 var blob = new Blob([JSONProject], {type: "text/plain;charset=utf-8"});
-                saveAs(blob, wickProject.name+'-'+timeStamp()+'.json');
+                saveAs(blob, wickProject.name+'.json');
             }, '\t');
             return;
         }
@@ -133,7 +133,7 @@ WickProject.Exporter = (function () {
                 var zip = new JSZip();
                 zip.file("index.html", fileOut);
                 zip.generateAsync({type:"blob"}).then(function(content) {
-                    saveAs(content, filename+'-'+timeStamp()+".zip");
+                    saveAs(content, filename+".zip");
                 });
             } else {
                 if(args && args.asNewWindow) {
@@ -141,7 +141,7 @@ WickProject.Exporter = (function () {
                     x.document.open().write(fileOut);
                 } else {
                     var blob = new Blob([fileOut], {type: "text/plain;charset=utf-8"});
-                    saveAs(blob, filename+'-'+timeStamp()+".html");
+                    saveAs(blob, filename+".html");
                 }
             }
         });

--- a/src/files/filehandler.js
+++ b/src/files/filehandler.js
@@ -46,7 +46,7 @@ export default function initializeDefaultFileHandlers() {
      * @param {function} failureCallback Callback to be called if save is unsuccessful.
      */
     window.saveFileFromWick = (file, name, extension, successCallback, failureCallback) => {
-      const filename = name + timeStamp() + extension; // name + timeStamp() + extension; // --HA
+      const filename = name + extension; // name + timeStamp() + extension; // --HA
       saveAs(file, filename);
       successCallback && successCallback() // Unfortunately, we can't check for success or failure from  browser...
     }


### PR DESCRIPTION
Remove timestamp from filenames.

I know this is such a small update to create a PR for but it's been on our plates for a long time so may as well take it out with an overkill. Also the timestamp is annoying and useless, especially considering that our file manager already tracks file names.