### PR TITLE
Fix brush tool breaking on layers with images or clips

### DIFF
--- a/engine/src/tools/Brush.js
+++ b/engine/src/tools/Brush.js
@@ -522,6 +522,7 @@ Wick.Tools.Brush = class extends Wick.Tool {
         var mask = null;
         layer.children.forEach(otherPath => {
             if(otherPath === mask) return;
+            if(!(otherPath instanceof this.paper.Path || otherPath instanceof this.paper.CompoundPath)) return;
             if(mask) {
                 var newMask = mask.unite(otherPath);
 


### PR DESCRIPTION
When clips or images are in the layer, the boolean operation breaks and the brush tool stops working. This fix makes sure that each child object is a path before including it in the boolean operation.