### PR TITLE
Fix bugs with color picker and add QoL

### DIFF
--- a/engine/src/tools/Cursor.js
+++ b/engine/src/tools/Cursor.js
@@ -117,6 +117,7 @@ Wick.Tools.Cursor = class extends Wick.Tool {
 
                 if(stopIndex !== null) {
                     this._selection.selectedStopIndex = stopIndex;
+					widget._updateItems();
                     this.fireEvent({eventName: 'canvasModified', actionName: 'cursorSelectStop'});
                 }
             }

--- a/engine/src/tools/Cursor.js
+++ b/engine/src/tools/Cursor.js
@@ -120,8 +120,12 @@ Wick.Tools.Cursor = class extends Wick.Tool {
 					widget._updateItems();
                     this.fireEvent({eventName: 'canvasModified', actionName: 'cursorSelectStop'});
                 }
+				
+				if((item && item.data.handleType && item.data.handleType.startsWith('gradient-'))
+				   || stopIndex !== null) return;
             }
-        } else if(this.hitResult.item && this.hitResult.item.data.isSelectionBoxGUI) {
+        }
+		if(this.hitResult.item && this.hitResult.item.data.isSelectionBoxGUI) {
 			// Clicked the selection box GUI, do nothing
 		} else if (this.hitResult.item && this._isItemSelected(this.hitResult.item)) {
 			// We clicked something that was already selected.

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -872,7 +872,8 @@ class SelectionWidget {
         }
 
         stopObj.data.setColor = (color) => {
-            colorBox.fillColor = color;
+            // if color is null, display black as placeholder
+            colorBox.fillColor = color || 'black';
             stopObj.data.color = color;
         }
         stopObj.data.setOffset = (offset) => {
@@ -1042,15 +1043,15 @@ class SelectionWidget {
         let color;
         if(!stop1) {
             // Offset is the leftmost stop, use the color of nextStop
-            color = stop2.data.color.clone();
+            color = stop2.data.color ? stop2.data.color.clone() : new paper.Color('black');
         } else if(!stop2) {
             // Offset is the rightmost stop, use the color of prevStop
-            color = stop1.data.color.clone();
+            color = stop1.data.color ? stop1.data.color.clone() : new paper.Color('black');
         } else {
             // Both stops exist, interpolate the color
             let offsetRelative = (offset - index1) / (index2 - index1);
-            let color1 = stop1.data.color;
-            let color2 = stop2.data.color;
+            let color1 = stop1.data.color || new paper.Color('black');
+            let color2 = stop2.data.color || new paper.Color('black');
             color = color1.add(color2.subtract(color1).multiply(offsetRelative));
             color.alpha = color1.alpha + (color2.alpha - color1.alpha) * offsetRelative;
         }

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -731,6 +731,9 @@ class SelectionWidget {
             color = item.fillColor;
             this._gradientGUI.stroke = false;
         }
+
+        if(!color) color = new paper.Color(0, 0, 0);
+
         if(color.gradient) {
             this._gradientGUI.radial = color.gradient.radial;
             stops = color.gradient.stops;

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -810,6 +810,7 @@ class SelectionWidget {
         const COLOR_BOX_CENTER = [0, -(SelectionWidget.COLOR_STOP_RECT_RADIUS + ARROW_HEIGHT)]
         const COLOR_BOX_INNER_SIZE = 2 * (SelectionWidget.COLOR_STOP_RECT_RADIUS - SelectionWidget.COLOR_STOP_RECT_PADDING);
         const COLOR_BOX_OUTER_SIZE = 2 * SelectionWidget.COLOR_STOP_RECT_RADIUS;
+        const CHECKER_SIZE = 8;
 
         let stopObj = new paper.Group({
             pivot: [0,0],
@@ -833,6 +834,17 @@ class SelectionWidget {
                 parentItem: stopObj
             }
         });
+        let opaqueColorBox = new paper.Path.Rectangle({
+            center: [-COLOR_BOX_INNER_SIZE/4, COLOR_BOX_CENTER[1]],
+            size: [COLOR_BOX_INNER_SIZE/2, COLOR_BOX_INNER_SIZE],
+            fillColor: 'red',
+            strokeWidth: 0,
+            data: {
+                isSelectionBoxGUI: true,
+                parentItem: stopObj,
+                isBorder: true
+            }
+        });
         let outerBox = new paper.Path.Rectangle({
             center: COLOR_BOX_CENTER,
             size: [COLOR_BOX_OUTER_SIZE, COLOR_BOX_OUTER_SIZE],
@@ -843,9 +855,32 @@ class SelectionWidget {
                 parentItem: stopObj
             }
         });
-
+        let checker = new paper.Group({
+            children: [
+                new paper.Path.Rectangle({ position: [0,0], size: CHECKER_SIZE*3, fillColor: '#e6e6e6',
+                    data: { isSelectionBoxGUI: true, parentItem: stopObj, isBorder: true }
+                }),
+                new paper.Path.Rectangle({ position: [0,-CHECKER_SIZE], size: CHECKER_SIZE, fillColor: '#d4d4d4',
+                    data: { isSelectionBoxGUI: true, parentItem: stopObj, isBorder: true }
+                }),
+                new paper.Path.Rectangle({ position: [-CHECKER_SIZE,0], size: CHECKER_SIZE, fillColor: '#d4d4d4',
+                    data: { isSelectionBoxGUI: true, parentItem: stopObj, isBorder: true }
+                }),
+                new paper.Path.Rectangle({ position: [0,CHECKER_SIZE],  size: CHECKER_SIZE, fillColor: '#d4d4d4',
+                    data: { isSelectionBoxGUI: true, parentItem: stopObj, isBorder: true }
+                }),
+                new paper.Path.Rectangle({ position: [CHECKER_SIZE,0],  size: CHECKER_SIZE, fillColor: '#d4d4d4',
+                    data: { isSelectionBoxGUI: true, parentItem: stopObj, isBorder: true }
+                })
+            ],
+            strokeWidth: 0
+        });
         outerBox.addTo(stopObj);
+        checker.position = COLOR_BOX_CENTER;
+        checker.scaling = COLOR_BOX_INNER_SIZE / (CHECKER_SIZE*3);
+        checker.addTo(stopObj);
         colorBox.addTo(stopObj);
+        opaqueColorBox.addTo(stopObj);
         let arrow;
         if(!isHover) {
             arrow = new paper.Path({
@@ -874,6 +909,9 @@ class SelectionWidget {
         stopObj.data.setColor = (color) => {
             // if color is null, display black as placeholder
             colorBox.fillColor = color || 'black';
+            opaqueColorBox.fillColor = color || 'black';
+            opaqueColorBox.fillColor.alpha = 1;
+
             stopObj.data.color = color;
         }
         stopObj.data.setOffset = (offset) => {

--- a/src/Editor/Panels/Inspector/Inspector.jsx
+++ b/src/Editor/Panels/Inspector/Inspector.jsx
@@ -247,22 +247,8 @@ class Inspector extends Component {
           onChangeIntermediate1={(col) => this.setSelectionAttributeIntermediate('fillColor', col)}
           enableGradient={true}
           selectionProps={{
-            setGradientActive: () => {
-              this.props.project.selection.useGradientGUI = 'fill';
-              this.props.project.selection.selectedStopIndex = 0;
-              this.props.project.view.render();
-            },
-            setGradientInactive: () => {
-              this.props.project.selection.useGradientGUI = false;
-              this.props.project.selection.selectedStopIndex = 0;
-              this.props.project.view.render();
-            },
-            getSelectedStopIndex: () => this.props.project.selection.selectedStopIndex,
-            setSelectedStopIndex: (index) => {
-              this.props.project.selection.selectedStopIndex = index;
-            },
-            selectedObjects: this.props.project.selection._selectedObjectsUUIDs.toSorted(),
-            selectedObjectsBounds: this.props.project.selection.view._getSelectedObjectsBounds(),
+            getSelection: () => this.props.project.selection,
+            renderSelection: () => this.props.project.view.render(),
             targetCanvas: this.props.project.view._svgCanvas
           }}
           id={"inspector-selection-fill-color"}
@@ -283,22 +269,8 @@ class Inspector extends Component {
           onChangeIntermediate1={(col) => this.setSelectionAttributeIntermediate('strokeColor', col)}
           enableGradient={true}
           selectionProps={{
-            setGradientActive: () => {
-              this.props.project.selection.useGradientGUI = 'stroke';
-              this.props.project.selection.selectedStopIndex = 0;
-              this.props.project.view.render();
-            },
-            setGradientInactive: () => {
-              this.props.project.selection.useGradientGUI = false;
-              this.props.project.selection.selectedStopIndex = 0;
-              this.props.project.view.render();
-            },
-            getSelectedStopIndex: () => this.props.project.selection.selectedStopIndex,
-            setSelectedStopIndex: (index) => {
-              this.props.project.selection.selectedStopIndex = index;
-            },
-            selectedObjects: this.props.project.selection._selectedObjectsUUIDs.toSorted(),
-            selectedObjectsBounds: this.props.project.selection.view._getSelectedObjectsBounds(),
+            getSelection: () => this.props.project.selection,
+            renderSelection: () => this.props.project.view.render(),
             targetCanvas: this.props.project.view._svgCanvas
           }}
           id={"inspector-selection-stroke-color"}

--- a/src/Editor/Panels/MobileContainer/MobileInspector/MobileInspector.jsx
+++ b/src/Editor/Panels/MobileContainer/MobileInspector/MobileInspector.jsx
@@ -234,22 +234,8 @@ class MobileInspector extends Component {
             onChangeIntermediate={(col) => this.setSelectionAttributeIntermediate('strokeColor', col)}
             enableGradient={true}
             selectionProps={{
-              setGradientActive: () => {
-                this.props.project.selection.useGradientGUI = 'fill';
-                this.props.project.selection.selectedStopIndex = 0;
-                this.props.project.view.render();
-              },
-              setGradientInactive: () => {
-                this.props.project.selection.useGradientGUI = false;
-                this.props.project.selection.selectedStopIndex = 0;
-                this.props.project.view.render();
-              },
-              getSelectedStopIndex: () => this.props.project.selection.selectedStopIndex,
-              setSelectedStopIndex: (index) => {
-                this.props.project.selection.selectedStopIndex = index;
-              },
-              selectedObjects: this.props.project.selection._selectedObjectsUUIDs.toSorted(),
-              selectedObjectsBounds: this.props.project.selection.view._getSelectedObjectsBounds(),
+              getSelection: () => this.props.project.selection,
+              renderSelection: () => this.props.project.view.render(),
               targetCanvas: this.props.project.view._svgCanvas
             }}
             id={"mobile-inspector-selection-stroke-color"}
@@ -268,22 +254,8 @@ class MobileInspector extends Component {
             onChangeIntermediate={(col) => this.setSelectionAttributeIntermediate('fillColor', col)}
             enableGradient={true}
             selectionProps={{
-              setGradientActive: () => {
-                this.props.project.selection.useGradientGUI = 'fill';
-                this.props.project.selection.selectedStopIndex = 0;
-                this.props.project.view.render();
-              },
-              setGradientInactive: () => {
-                this.props.project.selection.useGradientGUI = false;
-                this.props.project.selection.selectedStopIndex = 0;
-                this.props.project.view.render();
-              },
-              getSelectedStopIndex: () => this.props.project.selection.selectedStopIndex,
-              setSelectedStopIndex: (index) => {
-                this.props.project.selection.selectedStopIndex = index;
-              },
-              selectedObjects: this.props.project.selection._selectedObjectsUUIDs.toSorted(),
-              selectedObjectsBounds: this.props.project.selection.view._getSelectedObjectsBounds(),
+              getSelection: () => this.props.project.selection,
+              renderSelection: () => this.props.project.view.render(),
               targetCanvas: this.props.project.view._svgCanvas
             }}
             id={"mobile-inspector-selection-fill-color"}

--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -142,6 +142,10 @@ export default function ColorPicker (props) {
       colorCSSOpaque = `linear-gradient(rgb(${color.red*255},${color.green*255},${color.blue*255}))`;
     }
   }
+  else if (typeof color === 'string') {
+    // Used as a background-image
+    colorCSS = colorCSSOpaque = `linear-gradient(${color})`;
+  }
   // Bring desynced color state up, so if the solid-gradient state updates, the pop-up position updates
   const [desyncedColor, setDesyncedColor] = useState(color);
 
@@ -173,18 +177,16 @@ export default function ColorPicker (props) {
 
   return (
       <button
-        className="btn-color-picker"
+        className={"btn-color-picker" + (props.stroke ? " btn-color-picker-stroke" : "")}
         aria-label="color picker button"
         id={itemID}
         onClick={toggle}
-        style={props.stroke ?
-          { borderColor: colorCSS } :
-          { backgroundImage: `${colorCSS}, ${CHECKERBOARD_URL}`, backgroundColor: 'white' }
-        }>
-          {!props.stroke &&
+        style={{
+          backgroundImage: `${colorCSS}, ${CHECKERBOARD_URL}`,
+          backgroundColor: 'white'
+        }}>
           <div className="btn-color-picker-background-opaque"
             style={{ backgroundImage: colorCSSOpaque }} />
-          }
           <Popover
             tabIndex={-1}
             id={popoverID}

--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -81,10 +81,14 @@ function arraysEqual(arr1, arr2) {
 }
 
 export default function ColorPicker (props) {
+  let selectedObjects =
+    (typeof props.getSelection === 'function') ?
+    props.getSelection()._selectedObjectsUUIDs.toSorted() : null;
+
   const [open, setOpen] = useState(false);
-  const [lastObjects, setLastObjects] = useState(props.selectedObjects);
-  if (!arraysEqual(props.selectedObjects, lastObjects)) {
-    setLastObjects(props.selectedObjects);
+  const [lastObjects, setLastObjects] = useState(selectedObjects);
+  if (!arraysEqual(selectedObjects, lastObjects)) {
+    setLastObjects(selectedObjects);
 
     // Close pop-up if selection changed
     if (open)
@@ -106,7 +110,7 @@ export default function ColorPicker (props) {
     // Don't close if click started on popover
     // Don't close if clicked on selected objects
     let clickedCanvas = (e.touches ? e.target : data.downTarget) === props.targetCanvas;
-    let selectionUnchanged = arraysEqual(props.selectedObjects, lastObjects);
+    let selectionUnchanged = arraysEqual(selectedObjects, lastObjects);
     if (!data.clickedPopover && !(clickedCanvas && selectionUnchanged))
       setOpen(false);
   }
@@ -138,6 +142,32 @@ export default function ColorPicker (props) {
   }
   // Bring desynced color state up, so if the solid-gradient state updates, the pop-up position updates
   const [desyncedColor, setDesyncedColor] = useState(color);
+
+  // Bring functions involving selection down to avoid repeating code
+  let selectionGiven = (typeof props.getSelection === 'function');
+  let setGradientActive = (stopIndex) => {
+    if (!selectionGiven) return;
+    let selection = props.getSelection();
+
+    if (stopIndex !== undefined && selection.useGradientGUI) return;
+    selection.useGradientGUI = props.stroke ? 'stroke' : 'fill';
+    selection.selectedStopIndex = stopIndex || 0;
+    props.renderSelection();
+  };
+  let setGradientInactive = () => {
+    if (!selectionGiven) return;
+    let selection = props.getSelection();
+
+    selection.useGradientGUI = false;
+    selection.selectedStopIndex = 0;
+    props.renderSelection();
+  };
+  let getSelectedStopIndex = () => selectionGiven && props.getSelection().selectedStopIndex;
+  let setSelectedStopIndex = (index) => {
+    if (!selectionGiven) return;
+    props.getSelection().selectedStopIndex = index;
+  };
+  let selectedObjectsBounds = selectionGiven && props.getSelection().view._getSelectedObjectsBounds();
 
   return (
       <button
@@ -176,11 +206,11 @@ export default function ColorPicker (props) {
               onChangeComplete={props.onChangeComplete}
               onChangeIntermediate={props.onChangeIntermediate}
 
-              selectedObjectsBounds={props.selectedObjectsBounds}
-              setGradientActive={props.setGradientActive}
-              setGradientInactive={props.setGradientInactive}
-              getSelectedStopIndex={props.getSelectedStopIndex}
-              setSelectedStopIndex={props.setSelectedStopIndex}
+              selectedObjectsBounds={selectedObjectsBounds}
+              setGradientActive={setGradientActive}
+              setGradientInactive={setGradientInactive}
+              getSelectedStopIndex={getSelectedStopIndex}
+              setSelectedStopIndex={setSelectedStopIndex}
 
               lastColorsUsed={props.lastColorsUsed}
               updateLastColors={props.updateLastColors}

--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -132,13 +132,15 @@ export default function ColorPicker (props) {
       sortedControlStops.forEach(paperControlStop => {
           colorCSS += `, ${paperControlStop.color.toCSS()} ${paperControlStop.offset * 100}%`;
           let { red, green, blue } = paperControlStop.color;
-          colorCSSOpaque += `, rgb(${red*256},${green*256},${blue*256}) ${paperControlStop.offset * 100}%`;
+          colorCSSOpaque += `, rgb(${red*255},${green*255},${blue*255}) ${paperControlStop.offset * 100}%`;
       });
       colorCSS += ')';
       colorCSSOpaque += ')';
     }
-    else
-      colorCSS = color.toCSS();
+    else {
+      colorCSS = `linear-gradient(${color.toCSS()})`;
+      colorCSSOpaque = `linear-gradient(rgb(${color.red*255},${color.green*255},${color.blue*255}))`;
+    }
   }
   // Bring desynced color state up, so if the solid-gradient state updates, the pop-up position updates
   const [desyncedColor, setDesyncedColor] = useState(color);
@@ -177,11 +179,9 @@ export default function ColorPicker (props) {
         onClick={toggle}
         style={props.stroke ?
           { borderColor: colorCSS } :
-          color.gradient ?
-          { backgroundImage: `${colorCSS}, ${CHECKERBOARD_URL}`, backgroundColor: 'white' } :
-          { backgroundColor: colorCSS }
+          { backgroundImage: `${colorCSS}, ${CHECKERBOARD_URL}`, backgroundColor: 'white' }
         }>
-          {(!props.stroke && color.gradient) &&
+          {!props.stroke &&
           <div className="btn-color-picker-background-opaque"
             style={{ backgroundImage: colorCSSOpaque }} />
           }

--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -145,6 +145,8 @@ export default function ColorPicker (props) {
   else if (typeof color === 'string') {
     // Used as a background-image
     colorCSS = colorCSSOpaque = `linear-gradient(${color})`;
+    // regex to remove alpha from color string
+    colorCSSOpaque = colorCSSOpaque.replace(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/g, 'rgb($1, $2, $3)');
   }
   // Bring desynced color state up, so if the solid-gradient state updates, the pop-up position updates
   const [desyncedColor, setDesyncedColor] = useState(color);

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/ColorPickerComponents.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/ColorPickerComponents.jsx
@@ -34,6 +34,7 @@ function GradientControlStop (props) {
 export function GradientSlider (props) {
     return (
         <WickCustomSlider className="wick-color-picker-gradient-slider"
+            getHoverColor={props.getHoverColor}
             onMouseDownContainer={props.containerDown}
             onMouseDownPointer={props.controlStopDown}
             onMouseMove={props.onMouseMove}

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/WickCustomSlider.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/WickCustomSlider.jsx
@@ -11,6 +11,7 @@ class WickCustomSlider extends Component {
     }
     componentWillUnmount () {
         this.unbindEvents();
+        this.state.hoverOffset = null;
     }
     calculateOffset = (e) => {
         if (!this.container.current) return;
@@ -99,6 +100,7 @@ class WickCustomSlider extends Component {
                 <div className="wick-custom-slider-background"
                     ref={this.container}
                     onMouseMove={this.handleContainerHover}
+                    onMouseLeave={this.handleContainerExit}
                     onMouseDown={e => {this.handleContainer(e); this.bindEvents();}}
                     onTouchStart={this.handleContainer}
                     onTouchMove={this.handleMouseMove}
@@ -119,6 +121,7 @@ class WickCustomSlider extends Component {
         else
             this.setState({ hoverOffset: this.calculateOffset(e) });
     }
+    handleContainerExit = (e) => this.setState({ hoverOffset: null });
     renderHoverPointer () {
         if (!this.state.hoverOffset) return (<></>);
         let offset = this.state.hoverOffset,

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/WickCustomSlider.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/WickCustomSlider.jsx
@@ -4,6 +4,10 @@ class WickCustomSlider extends Component {
     constructor () {
         super();
         this.container = createRef(null);
+        this.state = {
+            // Used to re-render the hover pointer
+            hoverOffset: null
+        };
     }
     componentWillUnmount () {
         this.unbindEvents();
@@ -94,6 +98,7 @@ class WickCustomSlider extends Component {
                 style={this.props.style && this.props.style.container} >
                 <div className="wick-custom-slider-background"
                     ref={this.container}
+                    onMouseMove={this.handleContainerHover}
                     onMouseDown={e => {this.handleContainer(e); this.bindEvents();}}
                     onTouchStart={this.handleContainer}
                     onTouchMove={this.handleMouseMove}
@@ -101,8 +106,44 @@ class WickCustomSlider extends Component {
                     onTouchCancel={this.handleTouchEnd}
                     style={this.props.style && this.props.style.background}>
                     {this.renderPointers()}
+                    {this.props.getHoverColor && this.renderHoverPointer()}
                 </div>
             </div>
+        );
+    }
+
+    handleContainerHover = (e) => {
+        // Check if hovering over a pointer
+        if (e.target !== e.currentTarget || e.buttons !== 0)
+            this.setState({ hoverOffset: null });
+        else
+            this.setState({ hoverOffset: this.calculateOffset(e) });
+    }
+    renderHoverPointer () {
+        if (!this.state.hoverOffset) return (<></>);
+        let offset = this.state.hoverOffset,
+            style  = { position: 'absolute', pointerEvents: 'none' };
+        if (this.props.pointersDirection) {
+            if (this.props.pointersDirection === 'x') {
+                offset = offset.x;
+                style.left = `${offset * 100}%`;
+            }
+            else {
+                offset = offset.y;
+                style.top = `${offset * 100}%`;
+            }
+        }
+        else {
+            style.left = `${offset.x * 100}%`;
+            style.top  = `${offset.y * 100}%`;
+        }
+        return (
+            <this.props.pointerComponent className="wick-custom-slider-pointer"
+                stopIndex={-1}
+                color={this.props.getHoverColor(offset)}
+                pointerType={this.props.pointerType}
+                style={style}
+                {...this.props.pointerProps} />
         );
     }
 }

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
@@ -15,13 +15,13 @@ class WickGradient extends Component {
     }
     interpolateColor = (offset) => {
         const sortedStops = this.controlStops.toSorted((objectA, objectB) => objectA.offset - objectB.offset);
-        if (offset <= sortedStops[0].offset) return sortedStops[0].color;
-        if (offset >= sortedStops[sortedStops.length - 1].offset) return sortedStops[sortedStops.length - 1].color;
+        if (offset <= sortedStops[0].offset) return sortedStops[0].color || '#000000';
+        if (offset >= sortedStops[sortedStops.length - 1].offset) return sortedStops[sortedStops.length - 1].color || '#000000';
         let next = sortedStops.findIndex(stop => (stop.offset > offset));
         let firstStop = sortedStops[next - 1];
         let nextStop = sortedStops[next];
         let percent = (offset - firstStop.offset) / (nextStop.offset - firstStop.offset) * 100;
-        return tinycolor.mix(firstStop.color, nextStop.color, percent).toRgbString();
+        return tinycolor.mix(firstStop.color || '#000000', nextStop.color || '#000000', percent).toRgbString();
     }
 
     controlStopMouseDown = (index) => {
@@ -30,7 +30,8 @@ class WickGradient extends Component {
     }
     containerMouseDown = (offset) => {
         let color = this.interpolateColor(offset.x);
-        this.controlStops.push({ color, offset: offset.x });
+        // if color is null, use black as default
+        this.controlStops.push({ color: color || '#000000', offset: offset.x });
         this.onChangeComplete({ stopIndex: this.controlStops.length - 1 });
     }
     colorSelectedStop = (color) => {
@@ -38,7 +39,7 @@ class WickGradient extends Component {
         this.controlStops[this.props.selectedControlStopIndex] = { color, offset };
     }
     offsetSelectedStop = (offset) => {
-        let color = this.controlStops[this.props.selectedControlStopIndex].color;
+        let color = this.controlStops[this.props.selectedControlStopIndex].color || '#000000';
         this.controlStops[this.props.selectedControlStopIndex] = { color, offset };
     }
     deleteSelectedStop = () => {
@@ -104,7 +105,7 @@ class WickGradient extends Component {
         let linearGradient = 'linear-gradient(to right';
         const sortedControlStops = this.controlStops.toSorted((objectA, objectB) => objectA.offset - objectB.offset);
         sortedControlStops.forEach(controlStopObject => {
-            linearGradient += `, ${controlStopObject.color} ${controlStopObject.offset * 100}%`
+            linearGradient += `, ${controlStopObject.color || '#000000'} ${controlStopObject.offset * 100}%`
         });
         linearGradient += ')';
         return linearGradient;
@@ -187,7 +188,7 @@ class WickGradient extends Component {
                 <WickColorPicker {...this.props}
                     onChangeIntermediate={color => { this.colorSelectedStop(color); this.onChangeIntermediate(); }}
                     onChangeComplete={color => { this.colorSelectedStop(color); this.onChangeComplete({ stopColor: color }); }}
-                    color={this.controlStops[this.props.selectedControlStopIndex].color} />
+                    color={this.controlStops[this.props.selectedControlStopIndex].color || new window.Wick.Color('#000000')} />
             </>
         );
     }

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
@@ -176,6 +176,7 @@ class WickGradient extends Component {
             <>
                 {this.renderHeader()}
                 <GradientSlider
+                    getHoverColor={offset => this.interpolateColor(offset)}
                     containerDown={this.containerMouseDown}
                     controlStopDown={this.controlStopMouseDown}
                     onMouseMove={offset => { this.offsetSelectedStop(offset.x); this.onChangeIntermediate(); }}

--- a/src/Editor/Util/ColorPicker/WickColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/WickColorPicker.jsx
@@ -38,7 +38,7 @@ class WickGradientColorPicker extends Component {
     onGradientChange = (color, args) => {
         // Set null gradient stops to black
         for(let stop of color.stops) {
-            stop.color = stop.color || '#000000';
+            if(!stop.color) stop.color = '#000000';
         }
 
         // Sort color stops, keep the selected stop

--- a/src/Editor/Util/ColorPicker/WickColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/WickColorPicker.jsx
@@ -36,6 +36,11 @@ class WickGradientColorPicker extends Component {
         this.setState({ colorOnDrag: null });
     }
     onGradientChange = (color, args) => {
+        // Set null gradient stops to black
+        for(let stop of color.stops) {
+            stop.color = stop.color || '#000000';
+        }
+
         // Sort color stops, keep the selected stop
         let index;
         if (args && typeof args.stopIndex === 'number') {

--- a/src/Editor/Util/ColorPicker/WickColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/WickColorPicker.jsx
@@ -201,6 +201,10 @@ class WickGradientColorPicker extends Component {
         }
         let bounds = this.reducePaperBounds(this.props.selectedObjectsBounds);
 
+        // Fixes bug where canvas gradient tool disappears on undo
+        if (color.stops) {
+            this.props.setGradientActive(index);
+        }
         return (
             <div className="wick-color-picker">
                 {this.renderHeader(color)}

--- a/src/Editor/Util/ColorPicker/_colorpicker.scss
+++ b/src/Editor/Util/ColorPicker/_colorpicker.scss
@@ -45,7 +45,10 @@
 .btn-color-picker-stroke .btn-color-picker-background-opaque {
   flex-basis: unset;
   height: 100%;
-  margin: 25% -4px -4px -4px;
+  // percent-based margin is calculated based on width of an element
+  // therefore, pill-shaped buttons (e.g. in inspector) need a workaround
+  margin: 0 -4px;
+  transform: translateY(50%); // cover bottom half
 }
 
 .color-picker-control-div {

--- a/src/Editor/Util/ColorPicker/_colorpicker.scss
+++ b/src/Editor/Util/ColorPicker/_colorpicker.scss
@@ -34,6 +34,19 @@
 .btn-color-picker-background-opaque {
   flex-basis: 50%;
 }
+.btn-color-picker-stroke {
+  overflow: visible;
+  background-origin: border-box, border-box;
+  background-clip: border-box, border-box;
+  border-color: transparent;
+  mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+.btn-color-picker-stroke .btn-color-picker-background-opaque {
+  flex-basis: unset;
+  height: 100%;
+  margin: 25% -4px -4px -4px;
+}
 
 .color-picker-control-div {
   display: flex;


### PR DESCRIPTION
Fixed gradient color-picking interactions with null colors and hitting undo while the picker is active.
Added the split solid/transparent color preview to all color pickers.
Added hover preview to creating a new stop inside the inspector.
Allowed clicking outside to exit the color picker.