### PR TITLE
fix: Set fill color for paths created from holes in erase tool

### DIFF
--- a/engine/src/view/paper-ext/Layer.erase.js
+++ b/engine/src/view/paper-ext/Layer.erase.js
@@ -70,6 +70,7 @@
             return resolvedHoles.indexOf(hole) === -1;
         }).forEach(hole => {
             hole.clockwise = !hole.clockwise;
+            hole.fillColor = compoundPath.fillColor;
             paper.project.activeLayer.addChild(hole);
         });
 


### PR DESCRIPTION
Fixes brush strokes created with "inside" or "outside" modes disappearing when erasing in the layer