### PR TITLE
Possible fix: Color picker preview doesn't show correct color

### DIFF
--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -140,8 +140,9 @@ export default function ColorPicker (props) {
       colorCSSOpaque += ')';
     }
     else {
-      colorCSS = `linear-gradient(${color.toCSS()})`;
-      colorCSSOpaque = `linear-gradient(rgb(${color.red*255},${color.green*255},${color.blue*255}))`;
+      colorCSS = color.toCSS(); colorCSSOpaque = `rgb(${color.red*255},${color.green*255},${color.blue*255})`;
+      colorCSS = `linear-gradient(${colorCSS}, ${colorCSS})`;
+      colorCSSOpaque = `linear-gradient(${colorCSSOpaque}, ${colorCSSOpaque})`;
     }
   }
   else if (typeof color === 'string') {

--- a/src/Editor/Util/ColorPicker/ColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPicker.jsx
@@ -83,7 +83,8 @@ function arraysEqual(arr1, arr2) {
 export default function ColorPicker (props) {
   let selectedObjects =
     (typeof props.getSelection === 'function') ?
-    props.getSelection()._selectedObjectsUUIDs.toSorted() : null;
+    [...props.getSelection()._selectedObjectsUUIDs] : null;
+  if (selectedObjects) selectedObjects.sort();
 
   const [open, setOpen] = useState(false);
   const [lastObjects, setLastObjects] = useState(selectedObjects);
@@ -128,7 +129,8 @@ export default function ColorPicker (props) {
     if (color.gradient) {
       colorCSS = colorCSSOpaque = 'linear-gradient(to right';
 
-      const sortedControlStops = color.gradient.stops.toSorted((objectA, objectB) => objectA.offset - objectB.offset);
+      const sortedControlStops = [...color.gradient.stops];
+      sortedControlStops.sort((objectA, objectB) => objectA.offset - objectB.offset);
       sortedControlStops.forEach(paperControlStop => {
           colorCSS += `, ${paperControlStop.color.toCSS()} ${paperControlStop.offset * 100}%`;
           let { red, green, blue } = paperControlStop.color;
@@ -144,9 +146,9 @@ export default function ColorPicker (props) {
   }
   else if (typeof color === 'string') {
     // Used as a background-image
-    colorCSS = colorCSSOpaque = `linear-gradient(${color})`;
+    colorCSS = colorCSSOpaque = `linear-gradient(${color}, ${color})`;
     // regex to remove alpha from color string
-    colorCSSOpaque = colorCSSOpaque.replace(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/g, 'rgb($1, $2, $3)');
+    colorCSSOpaque = colorCSSOpaque.replaceAll(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/g, 'rgb($1, $2, $3)');
   }
   // Bring desynced color state up, so if the solid-gradient state updates, the pop-up position updates
   const [desyncedColor, setDesyncedColor] = useState(color);

--- a/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
+++ b/src/Editor/Util/ColorPicker/ColorPickerComponents/WickGradient.jsx
@@ -14,7 +14,8 @@ class WickGradient extends Component {
         this.props.onUnmount();
     }
     interpolateColor = (offset) => {
-        const sortedStops = this.controlStops.toSorted((objectA, objectB) => objectA.offset - objectB.offset);
+        const sortedStops = [...this.controlStops];
+        sortedStops.sort((objectA, objectB) => objectA.offset - objectB.offset);
         if (offset <= sortedStops[0].offset) return sortedStops[0].color || '#000000';
         if (offset >= sortedStops[sortedStops.length - 1].offset) return sortedStops[sortedStops.length - 1].color || '#000000';
         let next = sortedStops.findIndex(stop => (stop.offset > offset));
@@ -103,7 +104,8 @@ class WickGradient extends Component {
     }
     renderGradientBackground () {
         let linearGradient = 'linear-gradient(to right';
-        const sortedControlStops = this.controlStops.toSorted((objectA, objectB) => objectA.offset - objectB.offset);
+        const sortedControlStops = [...this.controlStops];
+        sortedControlStops.sort((objectA, objectB) => objectA.offset - objectB.offset);
         sortedControlStops.forEach(controlStopObject => {
             linearGradient += `, ${controlStopObject.color || '#000000'} ${controlStopObject.offset * 100}%`
         });

--- a/src/Editor/Util/ColorPicker/WickColorPicker.jsx
+++ b/src/Editor/Util/ColorPicker/WickColorPicker.jsx
@@ -50,7 +50,7 @@ class WickGradientColorPicker extends Component {
             index = this.props.getSelectedStopIndex();
         }
         let selectedStop = color.stops[index];
-        color.stops = color.stops.toSorted((stop1, stop2) => stop1.offset - stop2.offset);
+        color.stops.sort((stop1, stop2) => stop1.offset - stop2.offset);
         let newIndex = color.stops.indexOf(selectedStop);
         if (newIndex < 0) newIndex = 0;
 


### PR DESCRIPTION
I can't replicate this bug, but a possibility is that it may be caused by code not supported by older devices. This fix replaces `.toSorted` and `linear-gradient` with only one color stop.