### PR TITLE
Possible fix: opaque color indicator not showing up on some devices

### DIFF
--- a/src/Editor/Util/ColorPicker/_colorpicker.scss
+++ b/src/Editor/Util/ColorPicker/_colorpicker.scss
@@ -32,6 +32,7 @@
   padding: 0;
 }
 .btn-color-picker-background-opaque {
+  width: 100%;
   flex-basis: 50%;
 }
 .btn-color-picker-stroke {


### PR DESCRIPTION
Just adds `width: 100%`, should fix it