### PR TITLE
settings save between sessions

### DIFF
--- a/engine/src/ToolSettings.js
+++ b/engine/src/ToolSettings.js
@@ -259,18 +259,9 @@ Wick.ToolSettings = class {
     loadSettingsFromLocalstorage () {
         Wick.ToolSettings.DEFAULT_SETTINGS.forEach(setting => {
             // Get stored tool setting if it exists.
-            localforage.getItem(this.getStorageKey(name)).then( (value) => {
-                if (value) {
-                    this._settings[args.name] = {
-                        type: args.type,
-                        name: args.name,
-                        value: type === 'color' ? new window.Wick.Color(value) : value,
-                        default: args.default,
-                        min: args.min,
-                        max: args.max,
-                        step: args.step,
-                        options: args.options,
-                    };
+            localforage.getItem(this.getStorageKey(setting.name)).then( (value) => {
+                if (value !== null && value !== undefined) {
+                    this._settings[setting.name].value = setting.type === 'color' ? new window.Wick.Color(value) : value;
                 }
             });
         });

--- a/engine/src/base/Timeline.js
+++ b/engine/src/base/Timeline.js
@@ -32,7 +32,7 @@ Wick.Timeline = class extends Wick.Base {
 
         this._playing = true;
 
-        this._fillGapsMethod = "auto_extend";
+        this._fillGapsMethod = localStorage.getItem('wickEditorFillGapsMethod') || "auto_extend";
         this._frameForced = false;
     }
 

--- a/engine/src/gui/GUIElement.js
+++ b/engine/src/gui/GUIElement.js
@@ -221,6 +221,22 @@ if(isTablet) {
     Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
     Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
 }
+// Restore saved frame size preference (overrides tablet/desktop default)
+const _savedFrameSize = localStorage.getItem('wickEditorFrameSizeMode');
+if(_savedFrameSize) switch(_savedFrameSize){
+    case 'small':
+        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
+        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
+        break;
+    case 'large':
+        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
+        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+        break;
+    case 'normal':
+    default:
+        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
+        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+}
 Wick.GUIElement.GRID_MARGIN = 1;
 
 Wick.GUIElement.TIMELINE_BACKGROUND_COLOR = '#2A2E30';

--- a/engine/src/gui/PopupMenu.js
+++ b/engine/src/gui/PopupMenu.js
@@ -33,6 +33,7 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             icon: 'gap_fill_extend_frames',
             clickFn: () => {
                 this.project.model.activeTimeline.fillGapsMethod = 'auto_extend';
+                localStorage.setItem('wickEditorFillGapsMethod', 'auto_extend');
                 this.projectWasModified();
             }
         });
@@ -42,6 +43,7 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             icon: 'gap_fill_empty_frames',
             clickFn: () => {
                 this.project.model.activeTimeline.fillGapsMethod = 'blank_frames';
+                localStorage.setItem('wickEditorFillGapsMethod', 'blank_frames');
                 this.projectWasModified();
             }
         });
@@ -52,6 +54,7 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
+                localStorage.setItem('wickEditorFrameSizeMode', 'small');
             }
         });
 
@@ -61,6 +64,7 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+                localStorage.setItem('wickEditorFrameSizeMode', 'normal');
             }
         });
 
@@ -70,6 +74,7 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+                localStorage.setItem('wickEditorFrameSizeMode', 'large');
             }
         });
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "candlestick",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "candlestick",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@ffmpeg/core": "^0.12.6",
         "@ffmpeg/ffmpeg": "^0.12.6",


### PR DESCRIPTION
The shortcut settings already saved within the local forage but weren't being loaded properly. Fixed that in `EditorSettings.jsx`, and added the timeline settings as well (gap fill mode and frame size in bottom left).

To test: 
- Adjust at least one shortcut setting (ex: change preview from <kbd>k</kbd> to <kbd>enter</kbd>)
- Edit onion skinning settings
- Change gap fill mode and/ or frame size preference (bottom left)
Then reload the window, and test to see if your same settings/ preferences are still set.