### PR TITLE
[Bug Fixing] MP4 Export Lower FPS & MP4 Imports on Linux

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.5.1", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.9.1", features = ["devtools"] }
+tauri = { version = "2.11", features = ["devtools"] }
 tauri-plugin-log = "2"
-tauri-plugin-fs = "2"
+tauri-plugin-fs = "2.5"
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/src/Editor/export/VideoExport.js
+++ b/src/Editor/export/VideoExport.js
@@ -157,24 +157,18 @@ class VideoExport {
     let inputs = ['-i', 'frame%12d.jpg']
     if (audio) inputs = inputs.concat(['-i', 'audio.wav'])
 
-    // Only apply setps filter if framerate is below ffmpeg's minimum
-    let filterArgs = []
-    if (project.framerate < 6)
-      filterArgs = ['-filter:v', 'setpts=' + (6 / project.framerate) + '*PTS']
-
     let dimensions = VideoExport._ensureValidDimensions(
       args.width || project.width,
       args.height || project.height
     )
 
     let command = [
-      '-r', '' + Math.max(6, project.framerate),
+      '-r', '' + project.framerate,
       '-s', dimensions.width + 'x' + dimensions.height,
       ...inputs,
       '-pix_fmt', 'yuv420p',
       '-q:v', '10',
       '-strict', '-2',
-      ...filterArgs, // break the filter params here
       'out.mp4',
     ]
 

--- a/src/Editor/import/MP4Import_Pure.js
+++ b/src/Editor/import/MP4Import_Pure.js
@@ -79,14 +79,16 @@ async function extractFramesFromMp4(file, { fps = DEFAULT_FPS, maxFrames = Infin
   const url = URL.createObjectURL(file)
   const video = document.createElement('video')
   video.src = url
-  video.crossOrigin = 'anonymous'
+  // NOTE: do NOT set crossOrigin on blob URLs — blob URLs are same-origin by definition
+  // else WebKitGTK (Linux/Tauri) treats the blob as a CORS fetch, which breaks seeking
   video.muted = true
   video.playsInline = true
 
   // Load da metadata stuff
   await new Promise((res, rej) => {
-    video.addEventListener('loadedmetadata', () => res(), { once: true })
-    video.addEventListener('error', () => rej(new Error('Video metadata load failed')), { once: true })
+    const timer = setTimeout(() => rej(new Error('Video metadata load timed out — the file may use an unsupported codec')), 15000)
+    video.addEventListener('loadedmetadata', () => { clearTimeout(timer); res() }, { once: true })
+    video.addEventListener('error', () => { clearTimeout(timer); rej(new Error('Video metadata load failed')) }, { once: true })
   })
 
   const duration = video.duration
@@ -105,10 +107,11 @@ async function extractFramesFromMp4(file, { fps = DEFAULT_FPS, maxFrames = Infin
   let frameIndex = 0
   while (t <= duration && frameIndex < maxFrames) {
     video.currentTime = t
-    // Wait for seek
+    // Wait for seek — timeout guards against WebKitGTK/GStreamer silently dropping seeked events -H.A.
     await new Promise((res, rej) => {
-      const onSeeked = () => { res(); cleanup() }
-      const onError = () => { rej(new Error('Seek failed')); cleanup() }
+      const timer = setTimeout(() => { cleanup(); rej(new Error('Seek timed out — the video may use an unsupported codec on this platform')) }, 10000)
+      const onSeeked = () => { clearTimeout(timer); res(); cleanup() }
+      const onError = () => { clearTimeout(timer); rej(new Error('Seek failed')); cleanup() }
       const cleanup = () => {
         video.removeEventListener('seeked', onSeeked)
         video.removeEventListener('error', onError)
@@ -129,6 +132,7 @@ async function extractFramesFromMp4(file, { fps = DEFAULT_FPS, maxFrames = Infin
   }
 
   URL.revokeObjectURL(url)
+  if (!frames.length) throw new Error('No frames could be extracted — the video may use an unsupported codec on this platform')
   return { frames, width: w, height: h, duration, fps }
 }
 


### PR DESCRIPTION
Hikaishi on Discord reported short delay in an MP4 she exported with the test editor exporter
After looking into it I realized we had an "FPS limit" from the older ffmpeg package implemented into the code forcing 6 FPS or higher, and the delay was caused by the exporter trying to make that 6 FPS fit within a 5 FPS framerate (as Hikaishi's animation was at 5 FPS)
I won't post Hikaishi's animation publicly here, but this issue can easily be tested by creating a quick animation in the project, give it around 20 frames with some movement to show its playing, and set the FPS anywhere from 2 to 5. Then export the animation and compare the results.
The short delay may be difficult to notice. 

There was another video _importing_ issue related to linux, reported on Discord by ImWilburr.
It's because in the MP4 importer, we set the crossOrigin to "anonymous," which in Linux causes WebKit to treat the video resource as a CORS fetch. GStreamer then tries to send CORS headers for a local blob, which either silently fails or causes the first seek to never fire the seeked event. There's also no timeout on the seeked event promise. Both of these issues are covered in this branch. 