### PR TITLE
Add moveable pivot to selection widget and clips

### DIFF
--- a/engine/src/base/Clip.js
+++ b/engine/src/base/Clip.js
@@ -53,6 +53,7 @@ Wick.Clip = class extends Wick.Tickable {
         this._isSynced = false;
 
         this._transformation = args.transformation || new Wick.Transformation();
+        this._pivot = args.pivot || [0,0];
 
         this.cursor = 'default';
 
@@ -74,6 +75,7 @@ Wick.Clip = class extends Wick.Tickable {
         var data = super._serialize(args);
 
         data.transformation = this.transformation.values;
+        data.pivot = this._pivot;
         data.timeline = this._timeline;
         data.animationType = this._animationType;
         data.singleFrameNumber = this._singleFrameNumber;
@@ -87,6 +89,7 @@ Wick.Clip = class extends Wick.Tickable {
         super._deserialize(data);
 
         this.transformation = new Wick.Transformation(data.transformation);
+        this.pivot = data.pivot;
         this._timeline = data.timeline;
         this._animationType = data.animationType || 'loop';
         this._singleFrameNumber = data.singleFrameNumber || 1;
@@ -547,6 +550,18 @@ Wick.Clip = class extends Wick.Tickable {
                 tween.transformation = this._transformation.copy();
             }
         }
+    }
+
+    /**
+     * The pivot point of the clip.
+     * @type {Array}
+     */
+    get pivot() {
+        return this._pivot;
+    }
+
+    set pivot(pivot) {
+        this._pivot = pivot;
     }
 
     /**

--- a/engine/src/tools/Cursor.js
+++ b/engine/src/tools/Cursor.js
@@ -350,6 +350,7 @@ Wick.Tools.Cursor = class extends Wick.Tool {
 			(this.hitResult.item.data.parentItem
 				&& this.hitResult.item.data.parentItem.data.handleType === 'gradient-stop')
 			|| this.hitResult.item.data.handleType === 'gradient-point'
+			|| this.hitResult.item.data.handleType === 'pivot'
 		) {
 			return this.CURSOR_GRAD;
 		} else if (this.hitResult.item.data.isSelectionBoxGUI) {

--- a/engine/src/view/View.Clip.js
+++ b/engine/src/view/View.Clip.js
@@ -172,7 +172,7 @@ Wick.View.Clip = class extends Wick.View {
 
         //this._radius = null;
 
-        this.group.pivot = new this.paper.Point(0,0);
+        this.group.pivot = this.model.pivot || new this.paper.Point(0,0);
         this.group.position.x = this.model.transformation.x;
         this.group.position.y = this.model.transformation.y;
         this.group.scaling.x = this.model.transformation.scaleX;
@@ -206,7 +206,7 @@ Wick.View.Clip = class extends Wick.View {
         });
         group.addChild(border);
 
-        group.pivot = new this.paper.Point(0,0);
+        group.pivot = this.model.pivot || new this.paper.Point(0,0);
         group.position.x = this.model.transformation.x;
         group.position.y = this.model.transformation.y;
         group.scaling.x = this.model.transformation.scaleX;

--- a/engine/src/view/View.Frame.js
+++ b/engine/src/view/View.Frame.js
@@ -138,6 +138,7 @@ Wick.View.Frame = class extends Wick.View {
                     opacity: child.opacity
 
                 });
+                wickClip.pivot = [child.pivot.x, child.pivot.y];
             }
         });
 

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -205,7 +205,8 @@ class SelectionWidget {
     }
 
     set currentTransformation(currentTransformation) {
-        if(['translate', 'scale-edge', 'scale-corner', 'rotate', 'gradient-stop', 'gradient-point', 'gradient-none'].indexOf(currentTransformation) === -1) {
+        if(['translate', 'scale-edge', 'scale-corner', 'rotate', 'move-pivot',
+            'gradient-stop', 'gradient-point', 'gradient-none'].indexOf(currentTransformation) === -1) {
             console.error('Paper.SelectionWidget: Invalid transformation type: ' + currentTransformation);
             currentTransformation = null;
         } else {
@@ -265,7 +266,11 @@ class SelectionWidget {
         this._ghost = this._buildGhost();
         this._layer.addChild(this._ghost);
 
-        if (item.data.handleType === 'rotation') {
+        if (item.data.handleType === 'pivot') {
+            this.currentTransformation = 'move-pivot';
+            this._newPivot = this.pivot;
+            this._ghost.remove();
+        } else if (item.data.handleType === 'rotation') {
             this.currentTransformation = 'rotate';
         } else if (item.data.handleType === 'scale') {
             if (item.data.handleEdge.includes('Center')) {
@@ -294,9 +299,9 @@ class SelectionWidget {
         }
 
         var modifiers = {
-            skew: e.modifiers.command,    // Skew when Ctrl/Cmd pressed
-            center: !e.modifiers.alt,     // Always scale from center unless Alt pressed
-            freescale: !e.modifiers.shift // Never retain proportions unless Shift pressed
+            skew: e.modifiers.command,   // Skew when Ctrl/Cmd pressed
+            center: !e.modifiers.alt,    // Always scale from center unless Alt pressed
+            constrain: e.modifiers.shift // Never retain proportions unless Shift pressed
         };
         var topLeft = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'leftCenter';
         var vertical = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'bottomCenter';
@@ -327,22 +332,28 @@ class SelectionWidget {
         let unrotatedPivot = this._truePivot;
         this._truePivot = this._truePivot.rotate(this.boxRotation, this.pivot);
 
-
-        if (this.currentTransformation === 'translate') {
+        if (this.currentTransformation === 'move-pivot') {
+            item.matrix.reset();
+            var initialDelta = e.point.subtract(this._initialPoint);
+            if (modifiers.constrain) {
+                var direction = new paper.Point({ length: 1, angle: Math.round(initialDelta.angle / 45) * 45 });
+                initialDelta = initialDelta.project(direction);
+            }
+            item.translate(initialDelta);
+            this._newPivot = item.position;
+        } else if (this.currentTransformation === 'translate') {
             this._ghost.matrix.reset();
             var initialDelta = e.point.subtract(this._initialPoint);
-            if (!modifiers.freescale) {
-                var angle = initialDelta.angle;
-                angle = Math.round(angle / 45) * 45 * Math.PI / 180;
-                var angleVector = new paper.Point(Math.cos(angle), Math.sin(angle));
-                initialDelta = initialDelta.project(angleVector);
+            if (modifiers.constrain) {
+                var direction = new paper.Point({ length: 1, angle: Math.round(initialDelta.angle / 45) * 45 });
+                initialDelta = initialDelta.project(direction);
             }
             this._ghost.data.offset = initialDelta;
             this._ghost.translate(initialDelta);
         } else if (this.currentTransformation === 'rotate') {
             this._ghost.matrix.reset();
             var rotateDelta = e.point.subtract(this._truePivot).angle - this._initialPoint.subtract(this._truePivot).angle;
-            if (!modifiers.freescale) {
+            if (modifiers.constrain) {
                 rotateDelta = Math.round(rotateDelta / 45) * 45;
             }
             this._ghost.rotate(rotateDelta, this._truePivot);
@@ -350,7 +361,7 @@ class SelectionWidget {
             var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot).subtract(unrotatedPivot);
             var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot).subtract(unrotatedPivot);
             var scaleFactor = currentPointRelative.divide(initialPointRelative);
-            if (!modifiers.freescale) {
+            if (modifiers.constrain) {
                 if (Math.abs(scaleFactor.x) < Math.abs(scaleFactor.y)) {
                     scaleFactor.x = Math.sign(scaleFactor.x) * Math.abs(scaleFactor.y);
                 } else {
@@ -406,7 +417,9 @@ class SelectionWidget {
 
         this._ghost.remove();
 
-        if (this.currentTransformation === 'translate') {
+        if (this.currentTransformation === 'move-pivot') {
+            if (this._newPivot) this.pivot = this._newPivot;
+        } else if (this.currentTransformation === 'translate') {
             this.translateSelection(this._ghost.data.offset);
         } else if (this.currentTransformation === 'rotate') {
             this.boxRotation += this._ghost.rotation;
@@ -557,7 +570,6 @@ class SelectionWidget {
             fillColor: SelectionWidget.PIVOT_FILL_COLOR,
             strokeColor: SelectionWidget.PIVOT_STROKE_COLOR,
         });
-        handle.locked = true;
         return handle;
     }
 

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -302,8 +302,34 @@ class SelectionWidget {
         var vertical = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'bottomCenter';
 
         this._ghost.matrix.reset();
+        this._ghost.rotate(-this.boxRotation, this.pivot);
+        if (modifiers.center) {
+            this._truePivot = this.pivot;
+        } else if (this.currentTransformation === 'scale-edge') {
+            this._truePivot = topLeft ? this._ghost.bounds.bottomRight : this._ghost.bounds.topLeft;
+        } else {
+            let bounds = this._ghost.bounds;
+            switch (item.data.handleEdge) {
+                case 'topRight':
+                    this._truePivot = bounds.bottomLeft;
+                    break;
+                case 'topLeft':
+                    this._truePivot = bounds.bottomRight;
+                    break;
+                case 'bottomRight':
+                    this._truePivot = bounds.topLeft;
+                    break;
+                case 'bottomLeft':
+                    this._truePivot = bounds.topRight;
+                    break;
+            }
+        }
+        let unrotatedPivot = this._truePivot;
+        this._truePivot = this._truePivot.rotate(this.boxRotation, this.pivot);
+
 
         if (this.currentTransformation === 'translate') {
+            this._ghost.matrix.reset();
             var initialDelta = e.point.subtract(this._initialPoint);
             if (!modifiers.freescale) {
                 var angle = initialDelta.angle;
@@ -313,38 +339,16 @@ class SelectionWidget {
             }
             this._ghost.data.offset = initialDelta;
             this._ghost.translate(initialDelta);
-        }
-        else if (this.currentTransformation === 'rotate') {
-            var rotateDelta = e.point.subtract(this.pivot).angle - this._initialPoint.subtract(this.pivot).angle;
+        } else if (this.currentTransformation === 'rotate') {
+            this._ghost.matrix.reset();
+            var rotateDelta = e.point.subtract(this._truePivot).angle - this._initialPoint.subtract(this._truePivot).angle;
             if (!modifiers.freescale) {
                 rotateDelta = Math.round(rotateDelta / 45) * 45;
             }
-            this._ghost.rotate(rotateDelta, this.pivot);
+            this._ghost.rotate(rotateDelta, this._truePivot);
         } else if (this.currentTransformation === 'scale-corner') {
-            this._ghost.rotate(-this.boxRotation, this.pivot);
-
-            if (modifiers.center) {
-                this._truePivot = this.pivot;
-            } else {
-                let bounds = this._ghost.bounds;
-                switch (item.data.handleEdge) {
-                    case 'topRight':
-                        this._truePivot = bounds.bottomLeft;
-                        break;
-                    case 'topLeft':
-                        this._truePivot = bounds.bottomRight;
-                        break;
-                    case 'bottomRight':
-                        this._truePivot = bounds.topLeft;
-                        break;
-                    case 'bottomLeft':
-                        this._truePivot = bounds.topRight;
-                        break;
-                }
-            }
-
-            var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot).subtract(this._truePivot);
-            var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot).subtract(this._truePivot);
+            var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot).subtract(unrotatedPivot);
+            var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot).subtract(unrotatedPivot);
             var scaleFactor = currentPointRelative.divide(initialPointRelative);
             if (!modifiers.freescale) {
                 if (Math.abs(scaleFactor.x) < Math.abs(scaleFactor.y)) {
@@ -355,54 +359,38 @@ class SelectionWidget {
             }
             this._ghost.data.scale = scaleFactor;
 
-            this._ghost.scale(scaleFactor, this._truePivot);
+            this._ghost.scale(scaleFactor, unrotatedPivot);
             this._ghost.rotate(this.boxRotation, this.pivot);
         } else {
-            this._ghost.rotate(-this.boxRotation, this.pivot);
-
-            if (modifiers.center) {
-                this._truePivot = this.pivot;
-            } else {
-                if (topLeft) {
-                    this._truePivot = this._ghost.bounds.bottomRight;
-                } else {
-                    this._truePivot = this._ghost.bounds.topLeft;
-                }
-            }
-
-            this._ghost.data.transform.reset();
-
             var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot);
             var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot);
 
+            this._ghost.data.transform.reset();
             if (!modifiers.skew || (modifiers.skew && e.modifiers.shift)) {
-                var scaleFactor = currentPointRelative.subtract(this._truePivot).divide(initialPointRelative.subtract(this._truePivot));
-                if (vertical) {
+                var scaleFactor = currentPointRelative.subtract(unrotatedPivot).divide(initialPointRelative.subtract(unrotatedPivot));
+                if (vertical)
                     scaleFactor.x = 1;
-                } else {
+                else
                     scaleFactor.y = 1;
-                }
 
                 this._ghost.data.transform.scale(scaleFactor)
             }
             if (modifiers.skew) {
                 var shearFactor = currentPointRelative.subtract(initialPointRelative).divide(this._ghost.bounds.height, this._ghost.bounds.width);
-                if (vertical) {
+                if (vertical)
                     shearFactor.y = 0;
-                } else {
+                else
                     shearFactor.x = 0;
-                }
-                if (modifiers.center) {
+
+                if (modifiers.center)
                     shearFactor = shearFactor.multiply(2);
-                }
-                if (topLeft) {
+                if (topLeft)
                     shearFactor = shearFactor.multiply(-1);
-                }
 
                 this._ghost.data.transform.shear(shearFactor);
             }
 
-            this._ghost.translate(this._truePivot.multiply(-1)).transform(this._ghost.data.transform).translate(this._truePivot);
+            this._ghost.translate(unrotatedPivot.multiply(-1)).transform(this._ghost.data.transform).translate(unrotatedPivot);
             this._ghost.rotate(this.boxRotation, this.pivot);
         }
     }
@@ -422,7 +410,7 @@ class SelectionWidget {
             this.translateSelection(this._ghost.data.offset);
         } else if (this.currentTransformation === 'rotate') {
             this.boxRotation += this._ghost.rotation;
-            this.rotateSelection(this._ghost.rotation);
+            this.rotateSelection(this._ghost.rotation, this._truePivot);
         } else if (this.currentTransformation === 'scale-corner') {
             this.scaleSelection(this._ghost.data.scale, this._truePivot);
         } else {
@@ -445,23 +433,26 @@ class SelectionWidget {
     /**
      *
      */
-    rotateSelection(angle) {
+    rotateSelection(angle, pivot = this.pivot) {
         this._itemsInSelection.forEach(item => {
-            item.rotate(angle, this.pivot);
+            item.rotate(angle, pivot);
         });
+
+        this.pivot = this.pivot.rotate(angle, pivot);
     }
 
     /**
      *
      */
     scaleSelection(scale, pivot = this.pivot) {
+        let unrotatedPivot = pivot.rotate(-this.boxRotation, this.pivot);
         this._itemsInSelection.forEach(item => {
             item.rotate(-this.boxRotation, this.pivot);
-            item.scale(scale, pivot);
+            item.scale(scale, unrotatedPivot);
             item.rotate(this.boxRotation, this.pivot);
         });
 
-        var newPivot = pivot.add(this.pivot.subtract(pivot).multiply(scale));
+        var newPivot = unrotatedPivot.add(this.pivot.subtract(unrotatedPivot).multiply(scale));
         this.pivot = newPivot.rotate(this.boxRotation, this.pivot);
     }
 
@@ -469,15 +460,16 @@ class SelectionWidget {
      *
      */
     transformSelection(matrix, pivot = this.pivot) {
+        let unrotatedPivot = pivot.rotate(-this.boxRotation, this.pivot);
         this._itemsInSelection.forEach(item => {
             item.rotate(-this.boxRotation, this.pivot);
-            item.translate(pivot.multiply(-1)).transform(matrix).translate(pivot);
+            item.translate(unrotatedPivot.multiply(-1)).transform(matrix).translate(unrotatedPivot);
             item.rotate(this.boxRotation, this.pivot);
         });
 
         // Note that the GUI won't show this pivot as the center because it doesn't account for skew.
         // The pivot point after the skew will look a bit off.
-        var newPivot = pivot.add(this.pivot.subtract(pivot).transform(matrix));
+        var newPivot = unrotatedPivot.add(this.pivot.subtract(unrotatedPivot).transform(matrix));
         this.pivot = newPivot.rotate(this.boxRotation, this.pivot);
     }
 

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -419,6 +419,8 @@ class SelectionWidget {
 
         if (this.currentTransformation === 'move-pivot') {
             if (this._newPivot) this.pivot = this._newPivot;
+            if (this._itemsInSelection.length === 1 && this._itemsInSelection[0] instanceof paper.Group)
+                this._itemsInSelection[0].pivot = this._itemsInSelection[0].globalToLocal(this._newPivot);
         } else if (this.currentTransformation === 'translate') {
             this.translateSelection(this._ghost.data.offset);
         } else if (this.currentTransformation === 'rotate') {

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -205,7 +205,7 @@ class SelectionWidget {
     }
 
     set currentTransformation(currentTransformation) {
-        if(['translate', 'scale', 'rotate', 'gradient-stop', 'gradient-point', 'gradient-none'].indexOf(currentTransformation) === -1) {
+        if(['translate', 'scale-edge', 'scale-corner', 'rotate', 'gradient-stop', 'gradient-point', 'gradient-none'].indexOf(currentTransformation) === -1) {
             console.error('Paper.SelectionWidget: Invalid transformation type: ' + currentTransformation);
             currentTransformation = null;
         } else {
@@ -268,167 +268,141 @@ class SelectionWidget {
         if (item.data.handleType === 'rotation') {
             this.currentTransformation = 'rotate';
         } else if (item.data.handleType === 'scale') {
-            this.currentTransformation = 'scale';
+            if (item.data.handleEdge.includes('Center')) {
+                this.currentTransformation = 'scale-edge';
+            }
+            else {
+                this.currentTransformation = 'scale-corner';
+            }
         } else {
             this.currentTransformation = 'translate';
         }
 
-        this._ghost.data.initialPosition = this._ghost.position;
+        this._initialPoint = e.point;
+        this._truePivot = this.pivot;
+        this._ghost.data.offset = new paper.Point(0, 0);
         this._ghost.data.scale = new paper.Point(1, 1);
+        this._ghost.data.transform = new paper.Matrix();
     }
 
     /**
      *
      */
     updateTransformation (item, e) {
-        if(this.currentTransformation.substring(0,8) === 'gradient') {
+        if(this.currentTransformation && this.currentTransformation.substring(0,8) === 'gradient') {
             return this.updateGradientTransformation(item, e);
         }
 
-        if (!this.mod || !this.mod.initiated) {
-            this.mod = {
-                initiated: true
-            }
-
-            this.mod.onePoint = new paper.Point(1, 1);
-            this.mod.initialPoint = e.point;
-
-            this.mod.truePivot = this.pivot;
-
-            if (this.currentTransformation === 'translate') {
-                this.mod.action = 'translate';
-                this.mod.initialPosition = this._ghost.position;
-            }
-            else if (this.currentTransformation === 'rotate') {
-                this.mod.action = 'rotate';
-                this.mod.rotateDelta = 0;
-                this.mod.initialAngle = this.mod.initialPoint.subtract(this.pivot).angle;
-                this.mod.initialBoxRotation = this.boxRotation || 0;
-            } else if (item.data.handleEdge.includes('Center')) {
-                this.mod.action = 'move-edge';
-                this.mod.topLeft = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'leftCenter';
-                this.mod.vertical = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'bottomCenter';
-
-                this.mod.transformMatrix = new paper.Matrix();
-            } else {
-                this.mod.action = 'move-corner';
-                this.mod.scaleFactor = this.mod.onePoint;
-            }
-        }
-
-        this.mod.modifiers = {
-            skew: e.modifiers.command, // Skew when Ctrl/Cmd pressed
-            center: !e.modifiers.alt, // Always scale from center unless Alt pressed
+        var modifiers = {
+            skew: e.modifiers.command,    // Skew when Ctrl/Cmd pressed
+            center: !e.modifiers.alt,     // Always scale from center unless Alt pressed
             freescale: !e.modifiers.shift // Never retain proportions unless Shift pressed
-        }
+        };
+        var topLeft = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'leftCenter';
+        var vertical = item.data.handleEdge === 'topCenter' || item.data.handleEdge === 'bottomCenter';
 
-        if (this.mod.action === 'translate') {
-            var initialDelta = e.point.subtract(this.mod.initialPoint);
-            if (!this.mod.modifiers.freescale) {
+        this._ghost.matrix.reset();
+
+        if (this.currentTransformation === 'translate') {
+            var initialDelta = e.point.subtract(this._initialPoint);
+            if (!modifiers.freescale) {
                 var angle = initialDelta.angle;
-                angle = Math.round(Math.round(angle / 45) * 45) * Math.PI / 180;
+                angle = Math.round(angle / 45) * 45 * Math.PI / 180;
                 var angleVector = new paper.Point(Math.cos(angle), Math.sin(angle));
                 initialDelta = initialDelta.project(angleVector);
             }
-            this.mod.offset = initialDelta;
-            this._ghost.position = this.mod.initialPosition.add(initialDelta);
+            this._ghost.data.offset = initialDelta;
+            this._ghost.translate(initialDelta);
         }
-        else if (this.mod.action === 'rotate') {
-            this._ghost.rotate(-this.mod.rotateDelta, this.pivot);
-
-            var rotateDelta = e.point.subtract(this.pivot).angle - this.mod.initialAngle;
-            if (!this.mod.modifiers.freescale) {
-                rotateDelta = Math.round(Math.round(rotateDelta / 45) * 45);
+        else if (this.currentTransformation === 'rotate') {
+            var rotateDelta = e.point.subtract(this.pivot).angle - this._initialPoint.subtract(this.pivot).angle;
+            if (!modifiers.freescale) {
+                rotateDelta = Math.round(rotateDelta / 45) * 45;
             }
-            this.mod.rotateDelta = rotateDelta;
-            this.boxRotation = this.mod.initialBoxRotation + rotateDelta;
-
-            this._ghost.rotate(this.mod.rotateDelta, this.pivot);
-        } else if (this.mod.action === 'move-corner') {
+            this._ghost.rotate(rotateDelta, this.pivot);
+        } else if (this.currentTransformation === 'scale-corner') {
             this._ghost.rotate(-this.boxRotation, this.pivot);
-            this._ghost.scale(this.mod.onePoint.divide(this.mod.scaleFactor), this.mod.truePivot);
 
-            if (this.mod.modifiers.center) {
-                this.mod.truePivot = this.pivot;
+            if (modifiers.center) {
+                this._truePivot = this.pivot;
             } else {
                 let bounds = this._ghost.bounds;
                 switch (item.data.handleEdge) {
                     case 'topRight':
-                        this.mod.truePivot = bounds.bottomLeft;
+                        this._truePivot = bounds.bottomLeft;
                         break;
                     case 'topLeft':
-                        this.mod.truePivot = bounds.bottomRight;
+                        this._truePivot = bounds.bottomRight;
                         break;
                     case 'bottomRight':
-                        this.mod.truePivot = bounds.topLeft;
+                        this._truePivot = bounds.topLeft;
                         break;
                     case 'bottomLeft':
-                        this.mod.truePivot = bounds.topRight;
+                        this._truePivot = bounds.topRight;
                         break;
                 }
             }
 
-            var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot).subtract(this.mod.truePivot);
-            var initialPointRelative = this.mod.initialPoint.rotate(-this.boxRotation, this.pivot).subtract(this.mod.truePivot);
+            var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot).subtract(this._truePivot);
+            var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot).subtract(this._truePivot);
             var scaleFactor = currentPointRelative.divide(initialPointRelative);
-            if (!this.mod.modifiers.freescale) {
+            if (!modifiers.freescale) {
                 if (Math.abs(scaleFactor.x) < Math.abs(scaleFactor.y)) {
                     scaleFactor.x = Math.sign(scaleFactor.x) * Math.abs(scaleFactor.y);
                 } else {
                     scaleFactor.y = Math.sign(scaleFactor.y) * Math.abs(scaleFactor.x);
                 }
             }
-            this.mod.scaleFactor = scaleFactor;
+            this._ghost.data.scale = scaleFactor;
 
-            this._ghost.scale(this.mod.scaleFactor, this.mod.truePivot);
+            this._ghost.scale(scaleFactor, this._truePivot);
             this._ghost.rotate(this.boxRotation, this.pivot);
         } else {
             this._ghost.rotate(-this.boxRotation, this.pivot);
-            this._ghost.translate(this.mod.truePivot.multiply(-1)).transform(this.mod.transformMatrix.inverted()).translate(this.mod.truePivot);
 
-            if (this.mod.modifiers.center) {
-                this.mod.truePivot = this.pivot;
+            if (modifiers.center) {
+                this._truePivot = this.pivot;
             } else {
-                if (this.mod.topLeft) {
-                    this.mod.truePivot = this._ghost.bounds.bottomRight;
+                if (topLeft) {
+                    this._truePivot = this._ghost.bounds.bottomRight;
                 } else {
-                    this.mod.truePivot = this._ghost.bounds.topLeft;
+                    this._truePivot = this._ghost.bounds.topLeft;
                 }
             }
 
-            this.mod.transformMatrix.reset();
+            this._ghost.data.transform.reset();
 
             var currentPointRelative = e.point.rotate(-this.boxRotation, this.pivot);
-            var initialPointRelative = this.mod.initialPoint.rotate(-this.boxRotation, this.pivot);
+            var initialPointRelative = this._initialPoint.rotate(-this.boxRotation, this.pivot);
 
-            if (!this.mod.modifiers.skew || (this.mod.modifiers.skew && e.modifiers.shift)) {
-                var scaleFactor = currentPointRelative.subtract(this.mod.truePivot).divide(initialPointRelative.subtract(this.mod.truePivot));
-                if (this.mod.vertical) {
+            if (!modifiers.skew || (modifiers.skew && e.modifiers.shift)) {
+                var scaleFactor = currentPointRelative.subtract(this._truePivot).divide(initialPointRelative.subtract(this._truePivot));
+                if (vertical) {
                     scaleFactor.x = 1;
                 } else {
                     scaleFactor.y = 1;
                 }
 
-                this.mod.transformMatrix.scale(scaleFactor)
+                this._ghost.data.transform.scale(scaleFactor)
             }
-            if (this.mod.modifiers.skew) {
+            if (modifiers.skew) {
                 var shearFactor = currentPointRelative.subtract(initialPointRelative).divide(this._ghost.bounds.height, this._ghost.bounds.width);
-                if (this.mod.vertical) {
+                if (vertical) {
                     shearFactor.y = 0;
                 } else {
                     shearFactor.x = 0;
                 }
-                if (this.mod.modifiers.center) {
+                if (modifiers.center) {
                     shearFactor = shearFactor.multiply(2);
                 }
-                if (this.mod.topLeft) {
+                if (topLeft) {
                     shearFactor = shearFactor.multiply(-1);
-                };
+                }
 
-                this.mod.transformMatrix.shear(shearFactor.transform(this.mod.transformMatrix.inverted()));
+                this._ghost.data.transform.shear(shearFactor);
             }
 
-            this._ghost.translate(this.mod.truePivot.multiply(-1)).transform(this.mod.transformMatrix).translate(this.mod.truePivot);
+            this._ghost.translate(this._truePivot.multiply(-1)).transform(this._ghost.data.transform).translate(this._truePivot);
             this._ghost.rotate(this.boxRotation, this.pivot);
         }
     }
@@ -444,18 +418,18 @@ class SelectionWidget {
 
         this._ghost.remove();
 
-        if (this.mod.action === 'translate') {
-            this.translateSelection(this.mod.offset);
-        } else if (this.mod.action === 'rotate') {
+        if (this.currentTransformation === 'translate') {
+            this.translateSelection(this._ghost.data.offset);
+        } else if (this.currentTransformation === 'rotate') {
+            this.boxRotation += this._ghost.rotation;
             this.rotateSelection(this._ghost.rotation);
-        } else if (this.mod.action === 'move-corner') {
-            this.scaleSelection(this.mod.scaleFactor, this.mod.truePivot);
+        } else if (this.currentTransformation === 'scale-corner') {
+            this.scaleSelection(this._ghost.data.scale, this._truePivot);
         } else {
-            this.transformSelection(this.mod.transformMatrix, this.mod.truePivot);
+            this.transformSelection(this._ghost.data.transform, this._truePivot);
         }
 
         this._currentTransformation = null;
-        this.mod.initiated = false;
     }
 
     /**

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -252,6 +252,7 @@ class SelectionWidget {
                 this._buildGUI();
             }
             this.layer.addChild(this.item);
+            this._pivotPointHandle.bringToFront();
         }
     }
 
@@ -572,6 +573,8 @@ class SelectionWidget {
             fillColor: SelectionWidget.PIVOT_FILL_COLOR,
             strokeColor: SelectionWidget.PIVOT_STROKE_COLOR,
         });
+        // Lock handle if it interferes with dragging the selection
+        handle.locked = (this.boundingBox.width <= 4*handle.bounds.width) && (this.boundingBox.height <= 4*handle.bounds.height);
         return handle;
     }
 


### PR DESCRIPTION
### Features
- Drag pivot handle to reposition
- When a single clip is selected, clip saves pivot offset
- Pivot handle locks when the selection box is too small (when both width and height are smaller than 4x the pivot size)
- Alt to rotate from opposite corner

Also the selection code was significantly cleaned up. I had previously contained all the changes to the selection tool in a `this.mod` object... no more of that. Some of the logic was simplified as well.