### PR TITLE
Changed PWA manifest to correctly name Candlestick

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Wick Editor",
-  "name": "Wick Editor",
+  "short_name": "Candlestick",
+  "name": "Candlestick",
   "icons": [
     {
       "src": "favicon.png",
@@ -10,6 +10,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#ffc600",
+  "background_color": "#ffc600"
 }


### PR DESCRIPTION
The `manifest.json` file (the one that makes it possible to _'save'_ candlestick as an app on your homescreen) still **incorrectly called the app 'Wick Editor'**.