### PR TITLE
Fix layer opacity inspector slider on empty layer

### DIFF
--- a/engine/src/base/Project.js
+++ b/engine/src/base/Project.js
@@ -1080,7 +1080,7 @@ orderDynamicFrames() {
      */
     tryToAutoCreateTween() {
         var frame = this.activeFrame;
-        if (frame.tweens.length > 0 && !frame.getTweenAtPosition(frame.getRelativePlayheadPosition())) {
+        if (frame && frame.tweens.length > 0 && !frame.getTweenAtPosition(frame.getRelativePlayheadPosition())) {
             frame.createTween();
         }
     }


### PR DESCRIPTION
Should be quick to merge, just adds a null check.

Inspector layer opacity slider sets `project.selection.opacity`, which calls `project.tryToAutoCreateTween()`. It checks for `project.activeFrame.tweens`, but if the layer has no frame at the current time, it errors out.