### PR TITLE
fix: Line tool diagonal snapping and angle

### DIFF
--- a/engine/src/tools/Line.js
+++ b/engine/src/tools/Line.js
@@ -160,15 +160,16 @@ Wick.Tools.Line = class extends Wick.Tool {
 			const dy = Math.abs(this.startPoint.y - e.point.y);
 			const dx = Math.abs(this.startPoint.x - e.point.x);
 
-			// diagnol
-			if (dy && dx && (dy / dx) > 0.5 && (dx / dy) > 0.5) {
+			// diagnol (tan(22.5) = 0.41421356237309503)
+			if (dy && dx && (dy / dx) > 0.41421356237309503 && (dx / dy) > 0.41421356237309503) {
 				const diff = {
 					x: this.endPoint.x - this.startPoint.x,
 					y: this.endPoint.y - this.startPoint.y
 				}
+				const length = (Math.abs(diff.y) + Math.abs(diff.x)) / 2
 				this.endPoint = {
-					x: this.startPoint.x + (dy + dx) / 2 * diff.x / Math.abs(diff.x),
-					y: this.startPoint.y + (dy + dx) / 2 * diff.y / Math.abs(diff.y)
+					x: this.startPoint.x + length * diff.x / Math.abs(diff.x),
+					y: this.startPoint.y + length * diff.y / Math.abs(diff.y)
 				}
 			} else if (dy > dx) // straight vertical
 				this.endPoint.x = this.startPoint.x;


### PR DESCRIPTION
### Description
Fixes two issues in the Line tool: line snapping not working when drawing a diagonal line, and angle to draw diagonal lines being slightly off.

### Testing
1. Open the Line tool and draw a line on the canvas.
2. Hold `Shift` to draw another line diagonally, and snap to a vertex on the first line. When snapping, the line's endpoint should not move with the mouse.
3. Move the endpoint to a `22.5` degree angle, halfway between diagonal and horizontal/vertical. The line should switch between diagonal and horizontal/vertical around this halfway angle.

https://github.com/user-attachments/assets/7002dfba-44bc-419a-869a-89aae0bef8b0