### PR TITLE
fix: Text box doesn't focus on first click

### DIFF
--- a/engine/src/tools/Text.js
+++ b/engine/src/tools/Text.js
@@ -76,11 +76,18 @@ Wick.Tools.Text = class extends Wick.Tool {
             return;
         }
 
+        let oldTargetOnClick = e.event.target.onclick;
+        const targetOnClick = targetEvent => {
+            oldTargetOnClick && oldTargetOnClick(targetEvent);
+            e.event.target.onclick = oldTargetOnClick;
+            this.editingText.focus();
+        }
         if (this.editingText) {
             this.finishEditingText();
         } else if(this.hoveredOverText) {
             this.editingText = this.hoveredOverText;
             e.item.edit(this.project.view.paper);
+            e.event.target.onclick = targetOnClick;
         } else {
             var text = new this.paper.PointText(e.point);
             text.justification = 'left';
@@ -99,6 +106,7 @@ Wick.Tools.Text = class extends Wick.Tool {
 
             this.editingText = wickText.view.item;
             this.editingText.edit(this.project.view.paper);
+            e.event.target.onclick = targetOnClick;
 
             //this.fireEvent('canvasModified');
         }

--- a/engine/src/view/paper-ext/TextItem.edit.js
+++ b/engine/src/view/paper-ext/TextItem.edit.js
@@ -85,6 +85,9 @@
                 self.attachTextArea(paper);
             }
         },
+        focus: function () {
+            editElem[0].focus();
+        },
         finishEditing: function() {
             editElem.remove();
         },


### PR DESCRIPTION
### Description
The gesture code in `View.Project.js` uses pointer capture to funnel mouse events onto the `<canvas>` element, which triggers [an `onclick` event](https://github.com/Candlestickers/Candlestick/blob/4266827a3c460fee7d9eb1120578b7c83c27ce52/engine/src/view/View.Project.js#L585) that defocuses the Text tool's text box.

This PR implements a hacky fix to avoid breaking the gesture code. `tools/Text.js` wraps the canvas `onclick` handler in a function that refocuses the text box then sets the `onclick` handler to the original handler.

Closes #96

### Testing
1. Switch to the Text tool.
2. Press left mouse button and release in the same location. The cursor should be focused on the text box.
3. Click anywhere else on the canvas to deselect the text.
4. Click back on the text to select it. The text box should be focused again.
5. Deselect the text.
6. Press left mouse button on the text, but drag the cursor outside the text box and release. The text should be focused again. **This behavior is different from Wick Editor 1.19.3**, where the text box would be deselected.

Personally, I like having the text focused in this case. ~Not a bug, but a feature lol~