### PR TITLE
fix: Paths edited by Path Cursor can sometimes retain detailed handles

### DIFF
--- a/engine/src/base/Project.js
+++ b/engine/src/base/Project.js
@@ -1171,6 +1171,8 @@ orderDynamicFrames() {
             });
         });
 
+        // Switch to cursor tool so we can interact with the selection
+        this.activeTool = 'cursor';
         this.selection.selectMultipleObjects(objectsToAdd);
     }
     

--- a/engine/src/tools/PathCursor.js
+++ b/engine/src/tools/PathCursor.js
@@ -275,7 +275,7 @@ Wick.Tools.PathCursor = class extends Wick.Tool {
             if (targetItem && targetItem.parent.className === 'CompoundPath') {
                 targetItem = targetItem.parent;
             }
-            if (this._getWickUUID(targetItem) !== this._getWickUUID(this.detailedEditing)) {
+            if (this._getWickUUID(targetItem) !== this._getWickUUID(this.detailedEditing) || !targetItem.fullySelected) {
                 // Hits an item, but not the one currently in detail edit - handle as a click with no hit.
                 return new this.paper.HitResult();
             }

--- a/engine/src/view/View.Path.js
+++ b/engine/src/view/View.Path.js
@@ -48,6 +48,9 @@ Wick.View.Path = class extends Wick.View {
         }
 
         this.importJSON(this.model.json);
+        if(!(this.model.project && this.model.project._activeTool && this.model.project._activeTool.name === 'pathcursor')) {
+            this.item.fullySelected = false;
+        }
 
         // Apply onion skin style if Needed
         // (This is done here in the Path code because we actually change the style of the path


### PR DESCRIPTION
### Description
If you use the Path Cursor's detailed editing on a path, on occasion, the path handles can somehow get stuck to the path. In this PR, each path checks if the project (if it exists) is using the Path Cursor tool, and if it ain't, the path quietly discards the selection handles and moves on.

### Testing
1. Create some paths.
2. Activate the Path Cursor.
3. Double-click on a path to enter detailed editing mode.
4. Move a vertex.
5. Switch to another tool. The detailed editing handles should be removed.
6. Undo once. The handles should still be removed. In previous versions the handles still appear.