### PR TITLE
Frame size slider

### DIFF
--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -61019,6 +61019,15 @@ Wick.GUIElement.Project = class extends Wick.GUIElement {
 
   _onMouseWheel(e) {
     e.preventDefault();
+    // Modifier + scroll: fire frame size event instead of scrolling
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+      var frameDelta = -(e.deltaY * e.deltaFactor);
+      this._canvas.dispatchEvent(new CustomEvent('wickFrameSizeScroll', {
+        detail: { delta: frameDelta },
+        bubbles: true
+      }));
+      return;
+    }
     var dx = e.deltaX * e.deltaFactor * 0.5;
     var dy = e.deltaY * e.deltaFactor * 0.5;
     this.scrollX += dx;

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -60284,7 +60284,10 @@ Wick.GUIElement.OnionSkinRange = class extends Wick.GUIElement {
 
     var seek = this.direction === 'right' ? this.model.project.onionSkinSeekForwards : this.model.project.onionSkinSeekBackwards;
     var width = seek * this.gridCellWidth;
-    var edgeWidth = this.gridCellWidth - Wick.GUIElement.PLAYHEAD_MARGIN * 2;
+    var margin = Wick.GUIElement.PLAYHEAD_MARGIN * 2;
+    if (this.gridCellWidth < Wick.GUIElement.GRID_SMALL_CELL_WIDTH)
+      margin *= (this.gridCellWidth - 8) / (Wick.GUIElement.GRID_SMALL_CELL_WIDTH - 8);
+    var edgeWidth = this.gridCellWidth - margin;
     var height = Wick.GUIElement.NUMBER_LINE_HEIGHT * 0.9; // Draw handle
 
     var grd = ctx.createLinearGradient(0, 0, width + edgeWidth, 0);

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -59307,6 +59307,8 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
 
   _mouseOverFrameEdge() {
     var widthPx = this.model.length * this.gridCellWidth;
+    var _hcw = this.gridCellWidth;
+    if (_hcw <= 16 && !this.model.isSelected) return null;
     var handlePx = Wick.GUIElement.FRAME_HANDLE_WIDTH;
     if (this.project.frameSizeMode === 'small') handlePx *= 0.5;
 

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -59171,17 +59171,27 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
       ctx.restore();
     } else {
       this.cursor = 'grab';
-    } // Frame scripts dot
+    } // Dot scale shared by script indicator and content dot
+    var _dcw = this.gridCellWidth;
+    var _dG = Wick.GUIElement;
+    var _dotScale;
+    if (_dcw <= _dG.GRID_SMALL_CELL_WIDTH) {
+      _dotScale = 0.5 + 0.25 * (_dcw / _dG.GRID_SMALL_CELL_WIDTH);
+    } else if (_dcw <= _dG.GRID_NORMAL_CELL_WIDTH) {
+      _dotScale = 0.75 + 0.25 * ((_dcw - _dG.GRID_SMALL_CELL_WIDTH) / (_dG.GRID_NORMAL_CELL_WIDTH - _dG.GRID_SMALL_CELL_WIDTH));
+    } else {
+      _dotScale = 1.0 + 0.25 * ((_dcw - _dG.GRID_NORMAL_CELL_WIDTH) / (_dG.GRID_LARGE_CELL_WIDTH - _dG.GRID_NORMAL_CELL_WIDTH));
+    }
 
-
+    // Frame scripts dot
     if (this.model.hasContentfulScripts) {
       ctx.fillStyle = Wick.GUIElement.FRAME_SCRIPT_DOT_COLOR;
       ctx.beginPath();
-      ctx.arc(this.gridCellWidth / 2, 0, Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * 1.3, 0, Math.PI);
+      ctx.arc(this.gridCellWidth / 2, 0, Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * _dotScale * 1.3, 0, Math.PI);
       ctx.fill();
-    } // Frame identifier
+    }
 
-
+    // Frame identifier
     if (this.model.identifier) {
       ctx.save();
       ctx.beginPath();
@@ -59206,13 +59216,7 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
       }
 
       ctx.lineWidth = Wick.GUIElement.FRAME_CONTENT_DOT_STROKE_WIDTH;
-      var r = Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS;
-
-      if (this.project.frameSizeMode === 'small') {
-        r *= 0.75;
-      } else if (this.project.frameSizeMode === 'large') {
-        r *= 1.25;
-      }
+      var r = Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * _dotScale;
 
       ctx.beginPath();
       ctx.arc(this.gridCellWidth / 2, this.gridCellHeight / 2, r, 0, 2 * Math.PI);

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -61589,24 +61589,27 @@ Wick.GUIElement.Tween = class extends Wick.GUIElement {
       // Draw an arrow pointing towards the next tween
       var nextTweenGridPosition = nextTween.playheadPosition - this.model.playheadPosition;
       var nextTweenPosition = nextTweenGridPosition * this.gridCellWidth;
-      var arrowSize = 5; // Line
+      var arrowSize = 5; // Only draw if there's enough room — otherwise the arrow flips or collapses
 
-      ctx.strokeStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
-      ctx.lineWidth = Wick.GUIElement.TWEEN_ARROW_STROKE_WIDTH;
-      ctx.beginPath();
-      ctx.moveTo(linePadding, 0);
-      ctx.lineTo(nextTweenPosition - linePadding, 0);
-      ctx.stroke(); // Arrow head
+      if (nextTweenPosition > linePadding * 2 + arrowSize) {
+		// Line
+		ctx.strokeStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
+		ctx.lineWidth = Wick.GUIElement.TWEEN_ARROW_STROKE_WIDTH;
+		ctx.beginPath();
+		ctx.moveTo(linePadding, 0);
+		ctx.lineTo(nextTweenPosition - linePadding, 0);
+		ctx.stroke(); // Arrow head
 
-      ctx.fillStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
-      ctx.beginPath();
-      ctx.moveTo(nextTweenPosition - linePadding, 0);
-      ctx.lineTo(nextTweenPosition - linePadding - arrowSize, -arrowSize);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.moveTo(nextTweenPosition - linePadding, 0);
-      ctx.lineTo(nextTweenPosition - linePadding - arrowSize, arrowSize);
-      ctx.stroke();
+		ctx.fillStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
+		ctx.beginPath();
+		ctx.moveTo(nextTweenPosition - linePadding, 0);
+		ctx.lineTo(nextTweenPosition - linePadding - arrowSize, -arrowSize);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.moveTo(nextTweenPosition - linePadding, 0);
+		ctx.lineTo(nextTweenPosition - linePadding - arrowSize, arrowSize);
+		ctx.stroke();
+      }
     } else if (this.model.playheadPosition !== this.model.parentFrame.length) {
       // There is no tween in front of this tween, so draw a dotted line to the end of the frame
       var tweenPos = this.model.playheadPosition * this.gridCellWidth;

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -61527,10 +61527,16 @@ Wick.GUIElement.Tween = class extends Wick.GUIElement {
     super.draw();
     var ctx = this.ctx;
     var r = Wick.GUIElement.TWEEN_DIAMOND_RADIUS;
+    var _tcw = this.gridCellWidth;
+    var _tG = Wick.GUIElement;
 
-    if (this.project.frameSizeMode === 'large') {
-      r *= 1.25;
-    } // Tween diamond
+    if(_tcw <= _tG.GRID_SMALL_CELL_WIDTH)
+      r *= 0.5+0.25 * (_tcw / _tG.GRID_SMALL_CELL_WIDTH);
+    else if(_tcw <= _tG.GRID_NORMAL_CELL_WIDTH)
+      r *= 0.75+0.25 * ((_tcw - _tG.GRID_SMALL_CELL_WIDTH) / (_tG.GRID_NORMAL_CELL_WIDTH - _tG.GRID_SMALL_CELL_WIDTH));
+    else
+      r *= 1+0.25 * ((_tcw - _tG.GRID_NORMAL_CELL_WIDTH) / (_tG.GRID_LARGE_CELL_WIDTH - _tG.GRID_NORMAL_CELL_WIDTH));
+    // Tween diamond
 
 
     ctx.save();

--- a/engine/src/export/zip/wickengine.js
+++ b/engine/src/export/zip/wickengine.js
@@ -59193,7 +59193,9 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
       ctx.restore();
     }
 
-    if (this.model.tweens.length === 0 && !this.model.sound) {
+    var _hideDot = this.model.identifier
+               || (Wick.GUIElement.HIDE_CONTENT_DOTS && !this.model.contentful);
+    if (this.model.tweens.length === 0 && !this.model.sound && !_hideDot) {
       // Frame contentful dot
       ctx.fillStyle = Wick.GUIElement.FRAME_CONTENT_DOT_COLOR;
 

--- a/engine/src/gui/Frame.js
+++ b/engine/src/gui/Frame.js
@@ -89,11 +89,23 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
             this.cursor = 'grab';
         }
 
+        // Dot scale shared by script indicator and content dot
+        var _dcw = this.gridCellWidth;
+        var _dG = Wick.GUIElement;
+        var _dotScale;
+        if(_dcw <= _dG.GRID_SMALL_CELL_WIDTH)
+            _dotScale = 0.5 + 0.25 * (_dcw / _dG.GRID_SMALL_CELL_WIDTH);
+        else if(_dcw <= _dG.GRID_NORMAL_CELL_WIDTH)
+            _dotScale = 0.75 + 0.25 * ((_dcw - _dG.GRID_SMALL_CELL_WIDTH) / (_dG.GRID_NORMAL_CELL_WIDTH - _dG.GRID_SMALL_CELL_WIDTH));
+        else
+            _dotScale = 1.0 + 0.25 * ((_dcw - _dG.GRID_NORMAL_CELL_WIDTH) / (_dG.GRID_LARGE_CELL_WIDTH - _dG.GRID_NORMAL_CELL_WIDTH));
+        
+
         // Frame scripts dot
         if(this.model.hasContentfulScripts) {
             ctx.fillStyle = Wick.GUIElement.FRAME_SCRIPT_DOT_COLOR;
             ctx.beginPath();
-            ctx.arc(this.gridCellWidth/2, 0, Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS*1.3, 0, Math.PI);
+            ctx.arc(this.gridCellWidth/2, 0, Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * _dotScale * 1.3, 0, Math.PI);
             ctx.fill();
         }
 
@@ -122,17 +134,6 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
             }
             ctx.lineWidth = Wick.GUIElement.FRAME_CONTENT_DOT_STROKE_WIDTH;
 
-            // dot radius: 22 >> .75; 38 >> 1; 62 >> 1.25
-            var _dcw = this.gridCellWidth;
-            var _dG = Wick.GUIElement;
-            var _dotScale;
-            if (_dcw <= _dG.GRID_SMALL_CELL_WIDTH) {
-                _dotScale = 0.5 + 0.25 * (_dcw / _dG.GRID_SMALL_CELL_WIDTH);
-            } else if (_dcw <= _dG.GRID_NORMAL_CELL_WIDTH) {
-                _dotScale = 0.75 + 0.25 * ((_dcw - _dG.GRID_SMALL_CELL_WIDTH) / (_dG.GRID_NORMAL_CELL_WIDTH - _dG.GRID_SMALL_CELL_WIDTH));
-            } else {
-                _dotScale = 1.0 + 0.25 * ((_dcw - _dG.GRID_NORMAL_CELL_WIDTH) / (_dG.GRID_LARGE_CELL_WIDTH - _dG.GRID_NORMAL_CELL_WIDTH));
-            }
             var r = Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * _dotScale;
 
             ctx.beginPath();

--- a/engine/src/gui/Frame.js
+++ b/engine/src/gui/Frame.js
@@ -109,7 +109,7 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
             ctx.restore();
         }
 
-        if(this.model.tweens.length === 0 && !this.model.sound) {
+        if(this.model.tweens.length === 0 && !this.model.sound && !Wick.GUIElement.HIDE_CONTENT_DOTS) {
             // Frame contentful dot
 
             ctx.fillStyle = Wick.GUIElement.FRAME_CONTENT_DOT_COLOR;

--- a/engine/src/gui/Frame.js
+++ b/engine/src/gui/Frame.js
@@ -237,6 +237,8 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
         // Scale handle hit-area proportionally to cell width (capped at 0.5× below small)
         var _hcw = this.gridCellWidth;
         var _hG = Wick.GUIElement;
+        // At very small cell widths, disable edge resize for unselected frames
+        if (_hcw <= 16 && !this.model.isSelected) return null;
         var _hScale = Math.min(1, _hcw / _hG.GRID_NORMAL_CELL_WIDTH);
         var handlePx = Math.round(_hG.FRAME_HANDLE_WIDTH * _hScale);
 

--- a/engine/src/gui/Frame.js
+++ b/engine/src/gui/Frame.js
@@ -120,12 +120,18 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
             }
             ctx.lineWidth = Wick.GUIElement.FRAME_CONTENT_DOT_STROKE_WIDTH;
 
-            var r = Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS;
-            if(this.project.frameSizeMode === 'small') {
-                r *= 0.75;
-            } else if(this.project.frameSizeMode === 'large') {
-                r *= 1.25;
+            // dot radius: 22 >> .75; 38 >> 1; 62 >> 1.25
+            var _dcw = this.gridCellWidth;
+            var _dG = Wick.GUIElement;
+            var _dotScale;
+            if (_dcw <= _dG.GRID_SMALL_CELL_WIDTH) {
+                _dotScale = 0.5 + 0.25 * (_dcw / _dG.GRID_SMALL_CELL_WIDTH);
+            } else if (_dcw <= _dG.GRID_NORMAL_CELL_WIDTH) {
+                _dotScale = 0.75 + 0.25 * ((_dcw - _dG.GRID_SMALL_CELL_WIDTH) / (_dG.GRID_NORMAL_CELL_WIDTH - _dG.GRID_SMALL_CELL_WIDTH));
+            } else {
+                _dotScale = 1.0 + 0.25 * ((_dcw - _dG.GRID_NORMAL_CELL_WIDTH) / (_dG.GRID_LARGE_CELL_WIDTH - _dG.GRID_NORMAL_CELL_WIDTH));
             }
+            var r = Wick.GUIElement.FRAME_CONTENT_DOT_RADIUS * _dotScale;
 
             ctx.beginPath();
             ctx.arc(this.gridCellWidth/2, this.gridCellHeight/2, r, 0, 2 * Math.PI);
@@ -226,9 +232,11 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
     /* helper function for frame edge dragging */
     _mouseOverFrameEdge () {
         var widthPx = this.model.length * this.gridCellWidth;
-        var handlePx = Wick.GUIElement.FRAME_HANDLE_WIDTH;
-
-        if(this.project.frameSizeMode === 'small') handlePx *= 0.5;
+        // Scale handle hit-area proportionally to cell width (capped at 0.5× below small)
+        var _hcw = this.gridCellWidth;
+        var _hG = Wick.GUIElement;
+        var _hScale = Math.min(1, _hcw / _hG.GRID_NORMAL_CELL_WIDTH);
+        var handlePx = Math.round(_hG.FRAME_HANDLE_WIDTH * _hScale);
 
         if(this.project._isDragging || !this.mouseInBounds()) {
             return null;

--- a/engine/src/gui/Frame.js
+++ b/engine/src/gui/Frame.js
@@ -109,7 +109,9 @@ Wick.GUIElement.Frame = class extends Wick.GUIElement {
             ctx.restore();
         }
 
-        if(this.model.tweens.length === 0 && !this.model.sound && !Wick.GUIElement.HIDE_CONTENT_DOTS) {
+        var _hideDot = this.model.identifier // avoid overlapping name label
+                   || (Wick.GUIElement.HIDE_CONTENT_DOTS && !this.model.contentful); // at xsmall, only hide empty-frame dots
+        if(this.model.tweens.length === 0 && !this.model.sound && !_hideDot) {
             // Frame contentful dot
 
             ctx.fillStyle = Wick.GUIElement.FRAME_CONTENT_DOT_COLOR;

--- a/engine/src/gui/GUIElement.js
+++ b/engine/src/gui/GUIElement.js
@@ -243,7 +243,7 @@ if (_savedFrameSizeValue !== null) {
         _h = Math.round(_G.GRID_NORMAL_CELL_HEIGHT + _t * (_G.GRID_LARGE_CELL_HEIGHT - _G.GRID_NORMAL_CELL_HEIGHT));
     }
     _G.GRID_DEFAULT_CELL_WIDTH = _w;
-    _G.GRID_DEFAULT_CELL_HEIGHT = _h;
+    _G.GRID_DEFAULT_CELL_HEIGHT = Math.max(_h, 30);
     _G.HIDE_CONTENT_DOTS = _v < 15;
 } else {
     const _savedFrameSize = localStorage.getItem('wickEditorFrameSizeMode');

--- a/engine/src/gui/GUIElement.js
+++ b/engine/src/gui/GUIElement.js
@@ -222,20 +222,45 @@ if(isTablet) {
     Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
 }
 // Restore saved frame size preference (overrides tablet/desktop default)
-const _savedFrameSize = localStorage.getItem('wickEditorFrameSizeMode');
-if(_savedFrameSize) switch(_savedFrameSize){
-    case 'small':
-        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
-        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
-        break;
-    case 'large':
-        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
-        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
-        break;
-    case 'normal':
-    default:
-        Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
-        Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+const _savedFrameSizeValue = localStorage.getItem('wickEditorFrameSizeValue');
+if (_savedFrameSizeValue !== null) {
+    const _v = parseInt(_savedFrameSizeValue);
+    const _G = Wick.GUIElement;
+    const _XSW = 8, _XSH = 16;
+    let _w, _h;
+    if (_v <= 50) {
+        const _t = _v / 50;
+        _w = Math.round(_XSW + _t * (_G.GRID_SMALL_CELL_WIDTH - _XSW));
+        const _ht = Math.max(_v, 25) / 50;
+        _h = Math.round(_XSH + _ht * (_G.GRID_SMALL_CELL_HEIGHT - _XSH));
+    } else if (_v <= 100) {
+        const _t = (_v - 50) / 50;
+        _w = Math.round(_G.GRID_SMALL_CELL_WIDTH + _t * (_G.GRID_NORMAL_CELL_WIDTH - _G.GRID_SMALL_CELL_WIDTH));
+        _h = Math.round(_G.GRID_SMALL_CELL_HEIGHT + _t * (_G.GRID_NORMAL_CELL_HEIGHT - _G.GRID_SMALL_CELL_HEIGHT));
+    } else {
+        const _t = (_v - 100) / 50;
+        _w = Math.round(_G.GRID_NORMAL_CELL_WIDTH + _t * (_G.GRID_LARGE_CELL_WIDTH - _G.GRID_NORMAL_CELL_WIDTH));
+        _h = Math.round(_G.GRID_NORMAL_CELL_HEIGHT + _t * (_G.GRID_LARGE_CELL_HEIGHT - _G.GRID_NORMAL_CELL_HEIGHT));
+    }
+    _G.GRID_DEFAULT_CELL_WIDTH = _w;
+    _G.GRID_DEFAULT_CELL_HEIGHT = _h;
+    _G.HIDE_CONTENT_DOTS = _v < 15;
+} else {
+    const _savedFrameSize = localStorage.getItem('wickEditorFrameSizeMode');
+    if(_savedFrameSize) switch(_savedFrameSize){
+        case 'small':
+            Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
+            Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
+            break;
+        case 'large':
+            Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
+            Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+            break;
+        case 'normal':
+        default:
+            Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
+            Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+    }
 }
 Wick.GUIElement.GRID_MARGIN = 1;
 

--- a/engine/src/gui/NumberLine.js
+++ b/engine/src/gui/NumberLine.js
@@ -76,10 +76,16 @@ Wick.GUIElement.NumberLine = class extends Wick.GUIElement {
     _drawCell (i) {
         var ctx = this.ctx;
 
-        var highlight = i===0 || (i%5 === 4);
+        var cellW = this.gridCellWidth;
+        var smallW = Wick.GUIElement.GRID_SMALL_CELL_WIDTH; // 22
+        // show every 5th when below the 'small' preset width
+        // show only every 10th when very compact (below half small width)
+        var highlight = cellW < (smallW * 0.5)
+            ? (i === 0 || i % 10 === 9)   // frames 1, 10, 20, 30...
+            : (i === 0 || i % 5 === 4);   // frames 1, 5, 10, 15...
 
         // Draw cell number
-        if(this.project.frameSizeMode !== 'small' || highlight) {
+        if(cellW >= smallW || highlight) {
             var fontSize = (i>=99) ? 13 : 16;
             var fontFamily = Wick.GUIElement.NUMBER_LINE_NUMBERS_FONT_FAMILY;
             ctx.font = fontSize + "px " + fontFamily;

--- a/engine/src/gui/OnionSkinRange.js
+++ b/engine/src/gui/OnionSkinRange.js
@@ -40,7 +40,10 @@ Wick.GUIElement.OnionSkinRange = class extends Wick.GUIElement {
         // Calculate positions of the handle
         var seek = this.direction === 'right' ? this.model.project.onionSkinSeekForwards : this.model.project.onionSkinSeekBackwards;
         var width = Math.max(seek * this.gridCellWidth, this.gridCellWidth/2);
-        var edgeWidth = this.gridCellWidth - Wick.GUIElement.PLAYHEAD_MARGIN * 2;
+        var margin = Wick.GUIElement.PLAYHEAD_MARGIN * 2;
+        if (this.gridCellWidth < Wick.GUIElement.GRID_SMALL_CELL_WIDTH)
+            margin *= (this.gridCellWidth - 8) / (Wick.GUIElement.GRID_SMALL_CELL_WIDTH - 8);
+        var edgeWidth = this.gridCellWidth - margin;
         var height = Wick.GUIElement.NUMBER_LINE_HEIGHT * 0.9;
 
         // Draw handle

--- a/engine/src/gui/Playhead.js
+++ b/engine/src/gui/Playhead.js
@@ -27,14 +27,17 @@ Wick.GUIElement.Playhead = class extends Wick.GUIElement {
 
         var ctx = this.ctx;
 
-        var margin = 0;
-        if(this.project.frameSizeMode === 'small') {
-            margin = 2;
-        } else if (this.project.frameSizeMode === 'normal') {
-            margin = 8;
-        } else if (this.project.frameSizeMode === 'large') {
-            margin = 20;
-        }
+        // Interpolate margin xsmall(8) >> 0; small(22) >> 2; normal(38) >> 8; large(62) >> 20
+        var _cw = this.gridCellWidth;
+        var _G = Wick.GUIElement;
+        var margin;
+        if (_cw <= _G.GRID_SMALL_CELL_WIDTH)
+            margin = Math.round((_cw / _G.GRID_SMALL_CELL_WIDTH) * 2);
+        else if(_cw <= _G.GRID_NORMAL_CELL_WIDTH)
+            margin = Math.round(2 + (_cw - _G.GRID_SMALL_CELL_WIDTH) / (_G.GRID_NORMAL_CELL_WIDTH - _G.GRID_SMALL_CELL_WIDTH) * 6);
+        else
+            margin = Math.round(8 + (_cw - _G.GRID_NORMAL_CELL_WIDTH) / (_G.GRID_LARGE_CELL_WIDTH - _G.GRID_NORMAL_CELL_WIDTH) * 12);
+        
 
         var height = Wick.GUIElement.NUMBER_LINE_HEIGHT - 2;
         var width = this.gridCellWidth - margin * 2;

--- a/engine/src/gui/PopupMenu.js
+++ b/engine/src/gui/PopupMenu.js
@@ -54,7 +54,9 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
+                Wick.GUIElement.HIDE_CONTENT_DOTS = false;
                 localStorage.setItem('wickEditorFrameSizeMode', 'small');
+                localStorage.setItem('wickEditorFrameSizeValue', '50');
             }
         });
 
@@ -64,7 +66,9 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+                Wick.GUIElement.HIDE_CONTENT_DOTS = false;
                 localStorage.setItem('wickEditorFrameSizeMode', 'normal');
+                localStorage.setItem('wickEditorFrameSizeValue', '100');
             }
         });
 
@@ -74,7 +78,9 @@ Wick.GUIElement.PopupMenu = class extends Wick.GUIElement {
             clickFn: () => {
                 Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH = Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
                 Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+                Wick.GUIElement.HIDE_CONTENT_DOTS = false;
                 localStorage.setItem('wickEditorFrameSizeMode', 'large');
+                localStorage.setItem('wickEditorFrameSizeValue', '150');
             }
         });
     };

--- a/engine/src/gui/Project.js
+++ b/engine/src/gui/Project.js
@@ -480,6 +480,15 @@ Wick.GUIElement.Project = class extends Wick.GUIElement {
     _onMouseWheel (e) {
         e.preventDefault();
         if (!this.model.isPublished) {
+            // Modifier + scroll (zoom instead of scroll if ctrl/ cmmd/ alt keys)
+            if (e.ctrlKey || e.metaKey || e.altKey) {
+                var frameDelta = -(e.deltaY * e.deltaFactor);
+                this._canvas.dispatchEvent(new CustomEvent('wickFrameSizeScroll', {
+                    detail: { delta: frameDelta },
+                    bubbles: true
+                }));
+                return;
+            }
             var dx = e.deltaX * e.deltaFactor * 0.5;
             var dy = e.deltaY * e.deltaFactor * 0.5;
             this.scrollX += dx;

--- a/engine/src/gui/Tween.js
+++ b/engine/src/gui/Tween.js
@@ -94,24 +94,27 @@ Wick.GUIElement.Tween = class extends Wick.GUIElement {
             var nextTweenPosition = nextTweenGridPosition * this.gridCellWidth;
             var arrowSize = 5;
 
-            // Line
-            ctx.strokeStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
-            ctx.lineWidth = Wick.GUIElement.TWEEN_ARROW_STROKE_WIDTH;
-            ctx.beginPath();
-            ctx.moveTo(linePadding, 0);
-            ctx.lineTo(nextTweenPosition - linePadding, 0);
-            ctx.stroke();
+            // Only draw if there's enough room
+            if (nextTweenPosition > linePadding * 2 + arrowSize) {
+                // Line
+                ctx.strokeStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
+                ctx.lineWidth = Wick.GUIElement.TWEEN_ARROW_STROKE_WIDTH;
+                ctx.beginPath();
+                ctx.moveTo(linePadding, 0);
+                ctx.lineTo(nextTweenPosition - linePadding, 0);
+                ctx.stroke();
 
-            // Arrow head
-            ctx.fillStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
-            ctx.beginPath();
-            ctx.moveTo(nextTweenPosition - linePadding, 0);
-            ctx.lineTo(nextTweenPosition - linePadding - arrowSize, -arrowSize);
-            ctx.stroke();
-            ctx.beginPath();
-            ctx.moveTo(nextTweenPosition - linePadding, 0);
-            ctx.lineTo(nextTweenPosition - linePadding - arrowSize, arrowSize);
-            ctx.stroke();
+                // Arrow head
+                ctx.fillStyle = Wick.GUIElement.TWEEN_ARROW_STROKE_COLOR;
+                ctx.beginPath();
+                ctx.moveTo(nextTweenPosition - linePadding, 0);
+                ctx.lineTo(nextTweenPosition - linePadding - arrowSize, -arrowSize);
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.moveTo(nextTweenPosition - linePadding, 0);
+                ctx.lineTo(nextTweenPosition - linePadding - arrowSize, arrowSize);
+                ctx.stroke();
+            }
         } else if (this.model.playheadPosition !== this.model.parentFrame.length) {
             // There is no tween in front of this tween, so draw a dotted line to the end of the frame
 

--- a/engine/src/gui/Tween.js
+++ b/engine/src/gui/Tween.js
@@ -33,9 +33,15 @@ Wick.GUIElement.Tween = class extends Wick.GUIElement {
         var ctx = this.ctx;
 
         var r = Wick.GUIElement.TWEEN_DIAMOND_RADIUS;
-        if(this.project.frameSizeMode === 'large') {
-            r *= 1.25;
-        }
+        var _tcw = this.gridCellWidth;
+        var _tG = Wick.GUIElement;
+        if (_tcw <= _tG.GRID_SMALL_CELL_WIDTH)
+            r *= 0.5+0.25 * (_tcw / _tG.GRID_SMALL_CELL_WIDTH);
+        else if (_tcw <= _tG.GRID_NORMAL_CELL_WIDTH)
+            r *= 0.75+0.25 * ((_tcw - _tG.GRID_SMALL_CELL_WIDTH) / (_tG.GRID_NORMAL_CELL_WIDTH - _tG.GRID_SMALL_CELL_WIDTH));
+        else
+            r *= 1.0+0.25 * ((_tcw - _tG.GRID_NORMAL_CELL_WIDTH) / (_tG.GRID_LARGE_CELL_WIDTH - _tG.GRID_NORMAL_CELL_WIDTH));
+        
 
         // Tween diamond
         ctx.save();

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -543,7 +543,7 @@ class Editor extends EditorCore {
                     h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
                 }
                 G.GRID_DEFAULT_CELL_WIDTH = w;
-                G.GRID_DEFAULT_CELL_HEIGHT = h;
+                G.GRID_DEFAULT_CELL_HEIGHT = Math.max(h, 30);
                 G.HIDE_CONTENT_DOTS = v < 15;
             }
         }

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -520,7 +520,33 @@ class Editor extends EditorCore {
      * Resets the editor in preparation for a project load.
      */
     resetEditorForLoad = () => {
-
+        // Re-apply saved frame size so HIDE_CONTENT_DOTS and cell dims are correct after every project load
+        if (window.Wick && window.Wick.GUIElement) {
+            const G = window.Wick.GUIElement;
+            const stored = localStorage.getItem('wickEditorFrameSizeValue');
+            if (stored !== null) {
+                const v = parseInt(stored);
+                const XSW = 8, XSH = 16;
+                let w, h;
+                if (v <= 50) {
+                    const t = v / 50;
+                    w = Math.round(XSW + t * (G.GRID_SMALL_CELL_WIDTH - XSW));
+                    const ht = Math.max(v, 25) / 50;
+                    h = Math.round(XSH + ht * (G.GRID_SMALL_CELL_HEIGHT - XSH));
+                } else if (v <= 100) {
+                    const t = (v - 50) / 50;
+                    w = Math.round(G.GRID_SMALL_CELL_WIDTH + t * (G.GRID_NORMAL_CELL_WIDTH - G.GRID_SMALL_CELL_WIDTH));
+                    h = Math.round(G.GRID_SMALL_CELL_HEIGHT + t * (G.GRID_NORMAL_CELL_HEIGHT - G.GRID_SMALL_CELL_HEIGHT));
+                } else {
+                    const t = (v - 100) / 50;
+                    w = Math.round(G.GRID_NORMAL_CELL_WIDTH + t * (G.GRID_LARGE_CELL_WIDTH - G.GRID_NORMAL_CELL_WIDTH));
+                    h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
+                }
+                G.GRID_DEFAULT_CELL_WIDTH = w;
+                G.GRID_DEFAULT_CELL_HEIGHT = h;
+                G.HIDE_CONTENT_DOTS = v < 15;
+            }
+        }
     }
 
     /**

--- a/src/Editor/EditorCore.jsx
+++ b/src/Editor/EditorCore.jsx
@@ -2364,12 +2364,14 @@ class EditorCore extends Component {
 
     extendFrame = () => {
         var frames = this.project.selection.getSelectedObjects('Frame');
+        if (frames.length === 0) frames = this.project.activeTimeline.activeFrames;
         this.project.extendFrames(frames);
         this.project.guiElement.draw();
     }
 
     shrinkFrame = () => {
         var frames = this.project.selection.getSelectedObjects('Frame');
+        if (frames.length === 0) frames = this.project.activeTimeline.activeFrames;
         this.project.shrinkFrames(frames);
         this.project.guiElement.draw();
     }

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -132,32 +132,38 @@ class EditorSettings extends Component {
             } style={{ height: '18px' }}/>
             Frame Size:
           </div>
-          <WickInput
-            type="select"
-            value={this.state.frameSizeMode}
-            options={[
-              { label: 'Small',  value: 'small'  },
-              { label: 'Normal', value: 'normal' },
-              { label: 'Large',  value: 'large'  },
-            ]}
-            onChange={(val) => {
-              const mode = val.value;
-              this.setState({ frameSizeMode: mode });
-              localStorage.setItem('wickEditorFrameSizeMode', mode);
-              if (window.Wick && window.Wick.GUIElement) {
-                if (mode === 'small') {
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
-                } else if (mode === 'large') {
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
-                } else {
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
-                  window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+          <div style={{ padding: '4px 2px 0' }}>
+            <input
+              type="range"
+              min="0"
+              max="2"
+              step="1"
+              value={{ small: 0, normal: 1, large: 2 }[this.state.frameSizeMode] ?? 1}
+              style={{ width: '100%', cursor: 'pointer' }}
+              onChange={(e) => {
+                const mode = ['small', 'normal', 'large'][parseInt(e.target.value)];
+                this.setState({ frameSizeMode: mode });
+                localStorage.setItem('wickEditorFrameSizeMode', mode);
+                if (window.Wick && window.Wick.GUIElement) {
+                  if (mode === 'small') {
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
+                  } else if (mode === 'large') {
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+                  } else {
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
+                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+                  }
                 }
-              }
-            }}
-          />
+              }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', opacity: 0.6, marginTop: '2px' }}>
+              <span>Small</span>
+              <span>Normal</span>
+              <span>Large</span>
+            </div>
+          </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '4px' }}>
             <img alt="" src={
               this.state.fillGapsMethod === 'blank_frames'

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -158,10 +158,10 @@ class EditorSettings extends Component {
                 }
               }}
             />
-            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', opacity: 0.6, marginTop: '2px' }}>
-              <span>Small</span>
-              <span>Normal</span>
-              <span>Large</span>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '4px' }}>
+              <img alt="Small"  src={iconFramesSmall}  style={{ height: '16px', opacity: 0.6 }} />
+              <img alt="Normal" src={iconFramesNormal} style={{ height: '16px', opacity: 0.6 }} />
+              <img alt="Large"  src={iconFramesLarge}  style={{ height: '16px', opacity: 0.6 }} />
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '4px' }}>

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -173,7 +173,7 @@ class EditorSettings extends Component {
                   G.GRID_DEFAULT_CELL_WIDTH  = w;
                   G.GRID_DEFAULT_CELL_HEIGHT = h;
                   // below value 15, hide the content dots
-                  G.HIDE_CONTENT_DOTS = v < 30;
+                  G.HIDE_CONTENT_DOTS = v < 15;
                 }
               }}
             />

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -36,7 +36,13 @@ class EditorSettings extends Component {
 
     this.state = {
       clipboardMode: localStorage.getItem('CandleClipboardMode') || 'wick',
-      frameSizeMode: localStorage.getItem('wickEditorFrameSizeMode') || 'normal',
+      frameSizeValue: (() => {
+        const stored = localStorage.getItem('wickEditorFrameSizeValue');
+        if (stored !== null) return parseInt(stored);
+        // migrate old string value
+        const legacy = localStorage.getItem('wickEditorFrameSizeMode');
+        return legacy === 'small' ? 0 : legacy === 'large' ? 100 : 50;
+      })(),
       fillGapsMethod: localStorage.getItem('wickEditorFillGapsMethod') || 'auto_extend',
     }
   }
@@ -126,8 +132,8 @@ class EditorSettings extends Component {
           <label className="editor-settings-group-title">Timeline</label>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <img alt="" src={
-              this.state.frameSizeMode === 'small' ? iconFramesSmall :
-              this.state.frameSizeMode === 'large' ? iconFramesLarge :
+              this.state.frameSizeValue <= 25 ? iconFramesSmall :
+              this.state.frameSizeValue >= 75 ? iconFramesLarge :
               iconFramesNormal
             } style={{ height: '18px' }}/>
             Frame Size:
@@ -136,25 +142,28 @@ class EditorSettings extends Component {
             <input
               type="range"
               min="0"
-              max="2"
+              max="100"
               step="1"
-              value={{ small: 0, normal: 1, large: 2 }[this.state.frameSizeMode] ?? 1}
+              value={this.state.frameSizeValue}
               style={{ width: '100%', cursor: 'pointer' }}
               onChange={(e) => {
-                const mode = ['small', 'normal', 'large'][parseInt(e.target.value)];
-                this.setState({ frameSizeMode: mode });
-                localStorage.setItem('wickEditorFrameSizeMode', mode);
+                const v = parseInt(e.target.value);
+                this.setState({ frameSizeValue: v });
+                localStorage.setItem('wickEditorFrameSizeValue', v);
                 if (window.Wick && window.Wick.GUIElement) {
-                  if (mode === 'small') {
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_SMALL_CELL_WIDTH;
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_SMALL_CELL_HEIGHT;
-                  } else if (mode === 'large') {
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_LARGE_CELL_WIDTH;
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_LARGE_CELL_HEIGHT;
+                  const G = window.Wick.GUIElement;
+                  let w, h;
+                  if (v <= 50) {
+                    const t = v / 50;
+                    w = Math.round(G.GRID_SMALL_CELL_WIDTH  + t * (G.GRID_NORMAL_CELL_WIDTH  - G.GRID_SMALL_CELL_WIDTH));
+                    h = Math.round(G.GRID_SMALL_CELL_HEIGHT + t * (G.GRID_NORMAL_CELL_HEIGHT - G.GRID_SMALL_CELL_HEIGHT));
                   } else {
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_WIDTH  = window.Wick.GUIElement.GRID_NORMAL_CELL_WIDTH;
-                    window.Wick.GUIElement.GRID_DEFAULT_CELL_HEIGHT = window.Wick.GUIElement.GRID_NORMAL_CELL_HEIGHT;
+                    const t = (v - 50) / 50;
+                    w = Math.round(G.GRID_NORMAL_CELL_WIDTH  + t * (G.GRID_LARGE_CELL_WIDTH  - G.GRID_NORMAL_CELL_WIDTH));
+                    h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
                   }
+                  G.GRID_DEFAULT_CELL_WIDTH  = w;
+                  G.GRID_DEFAULT_CELL_HEIGHT = h;
                 }
               }}
             />

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -171,7 +171,7 @@ class EditorSettings extends Component {
                     h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
                   }
                   G.GRID_DEFAULT_CELL_WIDTH  = w;
-                  G.GRID_DEFAULT_CELL_HEIGHT = h;
+                  G.GRID_DEFAULT_CELL_HEIGHT = Math.max(h, 30); // min height keeps layer buttons from overflowing
                   // below value 15, hide the content dots
                   G.HIDE_CONTENT_DOTS = v < 15;
                 }

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -39,9 +39,9 @@ class EditorSettings extends Component {
       frameSizeValue: (() => {
         const stored = localStorage.getItem('wickEditorFrameSizeValue');
         if (stored !== null) return parseInt(stored);
-        // migrate old string value
+        // migrate old string value (scale: 0=xsmall, 50=small, 100=normal, 150=large)
         const legacy = localStorage.getItem('wickEditorFrameSizeMode');
-        return legacy === 'small' ? 0 : legacy === 'large' ? 100 : 50;
+        return legacy === 'small' ? 50 : legacy === 'large' ? 150 : 100;
       })(),
       fillGapsMethod: localStorage.getItem('wickEditorFillGapsMethod') || 'auto_extend',
     }
@@ -132,9 +132,9 @@ class EditorSettings extends Component {
           <label className="editor-settings-group-title">Timeline</label>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <img alt="" src={
-              this.state.frameSizeValue <= 25 ? iconFramesSmall :
-              this.state.frameSizeValue >= 75 ? iconFramesLarge :
-              iconFramesNormal
+              this.state.frameSizeValue >= 125 ? iconFramesLarge :
+              this.state.frameSizeValue >= 75  ? iconFramesNormal :
+              iconFramesSmall
             } style={{ height: '18px' }}/>
             Frame Size:
           </div>
@@ -142,7 +142,7 @@ class EditorSettings extends Component {
             <input
               type="range"
               min="0"
-              max="100"
+              max="150"
               step="1"
               value={this.state.frameSizeValue}
               style={{ width: '100%', cursor: 'pointer' }}
@@ -152,25 +152,36 @@ class EditorSettings extends Component {
                 localStorage.setItem('wickEditorFrameSizeValue', v);
                 if (window.Wick && window.Wick.GUIElement) {
                   const G = window.Wick.GUIElement;
+                  // anchors: 0=xsmall(8,16), 50=small(22,32), 100=normal(38,42), 150=large(62,52)
+                  const XSW = 8, XSH = 16;
                   let w, h;
                   if (v <= 50) {
                     const t = v / 50;
+                    w = Math.round(XSW + t * (G.GRID_SMALL_CELL_WIDTH  - XSW));
+                    // below value 30, height stops shrinking (freeze at v=25 height)
+                    const ht = Math.max(v, 30) / 50;
+                    h = Math.round(XSH + ht * (G.GRID_SMALL_CELL_HEIGHT - XSH));
+                  } else if (v <= 100) {
+                    const t = (v - 50) / 50;
                     w = Math.round(G.GRID_SMALL_CELL_WIDTH  + t * (G.GRID_NORMAL_CELL_WIDTH  - G.GRID_SMALL_CELL_WIDTH));
                     h = Math.round(G.GRID_SMALL_CELL_HEIGHT + t * (G.GRID_NORMAL_CELL_HEIGHT - G.GRID_SMALL_CELL_HEIGHT));
                   } else {
-                    const t = (v - 50) / 50;
+                    const t = (v - 100) / 50;
                     w = Math.round(G.GRID_NORMAL_CELL_WIDTH  + t * (G.GRID_LARGE_CELL_WIDTH  - G.GRID_NORMAL_CELL_WIDTH));
                     h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
                   }
                   G.GRID_DEFAULT_CELL_WIDTH  = w;
                   G.GRID_DEFAULT_CELL_HEIGHT = h;
+                  // below value 15, hide the content dots
+                  G.HIDE_CONTENT_DOTS = v < 30;
                 }
               }}
             />
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '4px' }}>
-              <img alt="Small"  src={iconFramesSmall}  style={{ height: '16px', opacity: 0.6 }} />
-              <img alt="Normal" src={iconFramesNormal} style={{ height: '16px', opacity: 0.6 }} />
-              <img alt="Large"  src={iconFramesLarge}  style={{ height: '16px', opacity: 0.6 }} />
+            {/* icons pinned at their proportional track positions: small=50/150=33%, normal=100/150=67%, large=150/150=100% */}
+            <div style={{ position: 'relative', height: '20px', marginTop: '2px' }}>
+              <img alt="Small"  src={iconFramesSmall}  style={{ position: 'absolute', left: 'calc(33.3% - 8px)',  height: '16px', opacity: 0.6 }} />
+              <img alt="Normal" src={iconFramesNormal} style={{ position: 'absolute', left: 'calc(66.7% - 8px)',  height: '16px', opacity: 0.6 }} />
+              <img alt="Large"  src={iconFramesLarge}  style={{ position: 'absolute', left: 'calc(100% - 16px)', height: '16px', opacity: 0.6 }} />
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '4px' }}>

--- a/src/Editor/Panels/Timeline/Timeline.jsx
+++ b/src/Editor/Panels/Timeline/Timeline.jsx
@@ -53,6 +53,42 @@ class Timeline extends Component {
     let canvasContainerElem = this.canvasContainer.current;
     this.props.project.guiElement.canvasContainer = canvasContainerElem;
     this.props.project.guiElement.draw();
+    canvasContainerElem.addEventListener('wickFrameSizeScroll', this._onFrameSizeScroll);
+  }
+
+  componentWillUnmount () {
+    if (this.canvasContainer.current) {
+      this.canvasContainer.current.removeEventListener('wickFrameSizeScroll', this._onFrameSizeScroll);
+    }
+  }
+
+  _onFrameSizeScroll = (e) => {
+    const step = e.detail.delta > 0 ? 3 : -3;
+    const current = parseInt(localStorage.getItem('wickEditorFrameSizeValue') || '100');
+    const v = Math.max(0, Math.min(150, current + step));
+    localStorage.setItem('wickEditorFrameSizeValue', v);
+    if (window.Wick && window.Wick.GUIElement) {
+      const G = window.Wick.GUIElement;
+      const XSW = 8, XSH = 16;
+      let w, h;
+      if (v <= 50) {
+        const t = v / 50;
+        w = Math.round(XSW + t * (G.GRID_SMALL_CELL_WIDTH - XSW));
+        h = Math.round(XSH + t * (G.GRID_SMALL_CELL_HEIGHT - XSH));
+      } else if (v <= 100) {
+        const t = (v - 50) / 50;
+        w = Math.round(G.GRID_SMALL_CELL_WIDTH + t * (G.GRID_NORMAL_CELL_WIDTH - G.GRID_SMALL_CELL_WIDTH));
+        h = Math.round(G.GRID_SMALL_CELL_HEIGHT + t * (G.GRID_NORMAL_CELL_HEIGHT - G.GRID_SMALL_CELL_HEIGHT));
+      } else {
+        const t = (v - 100) / 50;
+        w = Math.round(G.GRID_NORMAL_CELL_WIDTH + t * (G.GRID_LARGE_CELL_WIDTH - G.GRID_NORMAL_CELL_WIDTH));
+        h = Math.round(G.GRID_NORMAL_CELL_HEIGHT + t * (G.GRID_LARGE_CELL_HEIGHT - G.GRID_NORMAL_CELL_HEIGHT));
+      }
+      G.GRID_DEFAULT_CELL_WIDTH = w;
+      G.GRID_DEFAULT_CELL_HEIGHT = Math.max(h, 30);
+      G.HIDE_CONTENT_DOTS = v < 15;
+    }
+    this.props.project.guiElement.draw();
   }
 
   componentDidUpdate () {

--- a/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
+++ b/src/Editor/PopOuts/WickCodeEditor/WickCodeEditor.jsx
@@ -336,6 +336,7 @@ export default function WickCodeEditor(props) {
             name="wick-ace-editor"
             focus={true}
             editorProps={{ $blockScrolling: Infinity }}
+            setOptions={{ useWorker: false }}
             onChange={scriptOnChange}
             onLoad={(editor) => setAceEditor(editor)}
             markers={mapErrorToMarkers(props.error)}


### PR DESCRIPTION
Added setting option for frame size to allow users to minimize the frame size smaller than the current, smallest limit.
Smaller frame size options have been requested multiple times on Discord by ~2 users. 

The setting option is a slider. 
This increases customizability to make the timeline feel closer to what may be more comfortable working with.