### PR TITLE
fix: reject invalid output filenames to prevent path traversal (V-002)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,6 +51,26 @@ struct Frame {
     data: Vec<u8>,
 }
 
+/// Validates a user-supplied output base name (no extension) for use in a
+/// filesystem path. Rejects (rather than silently rewriting) any input that
+/// is empty or contains characters outside `[A-Za-z0-9_-]`, so inputs like
+/// "../../etc/passwd" are refused outright instead of being transformed
+/// into something unexpectedly different (e.g. "../../foo" -> "foo").
+/// Closes CWE-22 (path traversal) for the `name` parameter that feeds
+/// `output_path` in `render_video_ffmpeg`.
+fn validate_output_name(name: &str) -> Result<&str, String> {
+    if name.is_empty() {
+        return Err("output name must not be empty".to_string());
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        return Err(format!(
+            "invalid output name {:?}: only ASCII letters, digits, '-' and '_' are allowed",
+            name
+        ));
+    }
+    Ok(name)
+}
+
 #[tauri::command]
 async fn render_video_ffmpeg(
     frames: Vec<Frame>,
@@ -82,14 +102,10 @@ async fn render_video_ffmpeg(
         ).map_err(|e| e.to_string())?;
     }
 
-    // Sanitize the user-supplied output name to prevent path traversal / injection
-    // via special characters (e.g. "../", "/", null bytes) ending up in file paths
-    // or command arguments.
-    let safe_name: String = name
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
-        .collect();
-    let safe_name = if safe_name.is_empty() { "output".to_string() } else { safe_name };
+    // Reject (rather than silently rewrite) an output name that could cause
+    // path traversal or otherwise place the rendered file outside the
+    // intended temp directory. See `validate_output_name` for the allow-list.
+    let safe_name = validate_output_name(&name)?;
 
     let output_path = temp_dir.join(format!("{}.mp4", safe_name));
 
@@ -240,5 +256,33 @@ fn handle_file_open(app_handle: &AppHandle, path: String) {
 
         let pending = app_handle.state::<PendingFiles>();
         pending.0.lock().unwrap().insert(label, path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_output_name;
+
+    #[test]
+    fn accepts_valid_names_unchanged() {
+        for valid in ["output", "my-video_01", "AbC123", "a", "___", "---"] {
+            assert_eq!(validate_output_name(valid), Ok(valid));
+        }
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(validate_output_name("").is_err());
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_separators() {
+        let bad_inputs = [
+            "../secret", "../../etc/passwd", "/etc/passwd", "a/../../b",
+            "a\\..\\b", "..\\..\\windows", "foo/bar", "foo\\bar", "..", "foo..bar",
+        ];
+        for input in bad_inputs {
+            assert!(validate_output_name(input).is_err(), "expected {:?} to be rejected", input);
+        }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -82,7 +82,16 @@ async fn render_video_ffmpeg(
         ).map_err(|e| e.to_string())?;
     }
 
-    let output_path = temp_dir.join(format!("{}.mp4", name));
+    // Sanitize the user-supplied output name to prevent path traversal / injection
+    // via special characters (e.g. "../", "/", null bytes) ending up in file paths
+    // or command arguments.
+    let safe_name: String = name
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    let safe_name = if safe_name.is_empty() { "output".to_string() } else { safe_name };
+
+    let output_path = temp_dir.join(format!("{}.mp4", safe_name));
 
     let mut cmd = Command::new("ffmpeg");
     cmd.current_dir(&temp_dir)


### PR DESCRIPTION
## Summary
Fixes a path-traversal issue (CWE-22) in `render_video_ffmpeg`
(`src-tauri/src/main.rs`): the user-supplied `name` parameter was used
to build `output_path` without validation, so a crafted project file
(e.g. `name = "../../../Users/me/Desktop/evil"`) could cause the
rendered `.mp4` to be written outside the intended temp render
directory.

## Scope correction from the original automated report
The original scanner report labeled this **CRITICAL** and described
"shell metacharacter injection" affecting both `name` and `fps`. That
framing doesn't hold up:

- `Command::new("ffmpeg")` in Rust does **not** invoke a shell, so
  there is no shell metacharacter injection here.
- `fps` is only ever used as `&fps.to_string()` passed as a single
  `Command` argument; it isn't used to construct any path.

The real, demonstrable issue is narrower: **`name` feeding
`output_path` allows path traversal / unintended output file
placement** (CWE-22). This PR fixes that specific issue.

## Fix
The previous fix in this PR stripped invalid characters from `name`
before use (silently turning `"../../foo"` into `"foo"`). This revision
replaces that with an explicit allow-list validator that **rejects**
invalid names outright instead of transforming them, so the security
boundary is explicit and a caller isn't surprised by a silently
different filename than the one they chose.

## Tests
Added `#[cfg(test)] mod tests` (first test in `src-tauri`) covering
valid names, empty names, and traversal/separator patterns. Run
locally with `cd src-tauri && cargo test` (no CI workflow exists yet
in this repo to run this automatically).

## Files changed
- `src-tauri/src/main.rs`

---
*Originally opened as an automated security fix by [OrbisAI
Security](https://orbisappsec.com); revised by the PR author to narrow
scope to the actual verifiable issue and strengthen the fix.*