### PR TITLE
Inspector pivot coordinates and mobile-friendly skew

### DIFF
--- a/engine/src/base/Selection.js
+++ b/engine/src/base/Selection.js
@@ -100,6 +100,7 @@ Wick.Selection = class extends Wick.Base {
             "height",
             "rotation",
             "shear",
+            "relativePivot",
             "opacity",
             "sound",
             "soundVolume",
@@ -588,6 +589,43 @@ Wick.Selection = class extends Wick.Base {
     set shear(shear) {
         this.project.tryToAutoCreateTween();
         this.view.shear = shear;
+    }
+
+    /** 
+     * The pivot location relative to the selection transform.
+     * @type {}
+     */
+    get relativePivot() {
+        var selectedObject = this.getSelectedObject();
+        if (selectedObject instanceof Wick.Clip) {
+            return { x: selectedObject.pivot[0], y: selectedObject.pivot[1] };
+        } else {
+            var center = this.view._getSelectedObjectsBounds().center;
+            var globalToLocal = (new paper.Matrix()).scale(1/this.scaleX, 1/this.scaleY).shear(-this.shear, 0).rotate(-this.rotation);
+            var relativePivot = globalToLocal.transform((new paper.Point(this._pivotPoint)).subtract(center));
+            return { x: relativePivot.x, y: relativePivot.y };
+        }
+    }
+
+    set relativePivot(relativePivot) {
+        this.project.tryToAutoCreateTween();
+        var selectedObject = this.getSelectedObject();
+        if (selectedObject instanceof Wick.Clip) {
+            var transformation = selectedObject.transformation;
+            var matrix = new paper.Matrix(transformation.matrix);
+
+            // Move the clip opposite the pivot so it appears stationary
+            var pivot = matrix.transform((new paper.Point(relativePivot)).subtract(selectedObject.pivot));
+            selectedObject.pivot = [relativePivot.x, relativePivot.y];
+            transformation.x = pivot.x; transformation.y = pivot.y;
+            selectedObject.transformation = transformation;
+            this.pivotPoint = { x: pivot.x, y: pivot.y };
+        } else {
+            var center = this.view._getSelectedObjectsBounds().center;
+            var localToGlobal = (new paper.Matrix()).rotate(this.rotation).shear(this.shear, 0).scale(this.scaleX, this.scaleY);
+            var pivot = localToGlobal.transform(relativePivot).add(center);
+            this.pivotPoint = { x: pivot.x, y: pivot.y };
+        }
     }
 
     /**

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -340,6 +340,7 @@ class SelectionWidget {
 
         this._ghost.matrix.reset();
         this._ghost.rotate(-this.boxRotation, this.pivot).shear(-this.boxShear, 0, this.pivot);
+        let unrotatedBounds = this._ghost.bounds.clone();
         if (modifiers.center) {
             this._truePivot = this.pivot;
         } else if (this.currentTransformation === 'scale-edge') {
@@ -370,6 +371,17 @@ class SelectionWidget {
             if (modifiers.constrain) {
                 var direction = new paper.Point({ length: 1, angle: Math.round(initialDelta.angle / 45) * 45 });
                 initialDelta = initialDelta.project(direction);
+            } else if (modifiers.center) {
+                let { topLeft, bottomLeft, bottomRight, topRight, topCenter, leftCenter, bottomCenter, rightCenter, center } = unrotatedBounds;
+                let snapPoints = [topLeft, bottomLeft, bottomRight, topRight, topCenter, leftCenter, bottomCenter, rightCenter, center];
+                let matrix = (new paper.Matrix()).translate(this.pivot).rotate(this.boxRotation).shear(this.boxShear, 0).translate(-this.pivot.x, -this.pivot.y);
+                for (let snapPoint of snapPoints) {
+                    snapPoint = matrix.transform(snapPoint);
+                    if (snapPoint.getDistance(e.point) <= SelectionWidget.PIVOT_SNAP_THRESHOLD / paper.view.zoom) {
+                        initialDelta = snapPoint.subtract(item.position);
+                        break;
+                    }
+                }
             }
             item.translate(initialDelta);
             this._newPivot = item.position;
@@ -1137,13 +1149,14 @@ class SelectionWidget {
 SelectionWidget.BOX_STROKE_WIDTH = 1;
 SelectionWidget.BOX_STROKE_COLOR = 'rgba(100,150,255,1.0)';
 SelectionWidget.HANDLE_RADIUS = 5;
-SelectionWidget.HANDLE_STROKE_WIDTH = SelectionWidget.BOX_STROKE_WIDTH
-SelectionWidget.HANDLE_STROKE_COLOR = SelectionWidget.BOX_STROKE_COLOR
+SelectionWidget.HANDLE_STROKE_WIDTH = SelectionWidget.BOX_STROKE_WIDTH;
+SelectionWidget.HANDLE_STROKE_COLOR = SelectionWidget.BOX_STROKE_COLOR;
 SelectionWidget.HANDLE_FILL_COLOR = 'rgba(255,255,255,0.3)';
 SelectionWidget.PIVOT_STROKE_WIDTH = SelectionWidget.BOX_STROKE_WIDTH;
 SelectionWidget.PIVOT_FILL_COLOR = 'rgba(255,255,255,0.5)';
 SelectionWidget.PIVOT_STROKE_COLOR = 'rgba(0,0,0,1)';
-SelectionWidget.PIVOT_RADIUS = SelectionWidget.HANDLE_RADIUS
+SelectionWidget.PIVOT_RADIUS = SelectionWidget.HANDLE_RADIUS;
+SelectionWidget.PIVOT_SNAP_THRESHOLD = SelectionWidget.PIVOT_RADIUS;
 SelectionWidget.ROTATION_HOTSPOT_RADIUS = 20;
 SelectionWidget.ROTATION_HOTSPOT_FILLCOLOR = 'rgba(100,150,255,0.5)';
 SelectionWidget.GHOST_STROKE_COLOR = 'rgba(0, 0, 0, 1.0)';

--- a/engine/src/view/paper-ext/Paper.SelectionWidget.js
+++ b/engine/src/view/paper-ext/Paper.SelectionWidget.js
@@ -317,6 +317,7 @@ class SelectionWidget {
 
         this._initialPoint = e.point;
         this._truePivot = this.pivot;
+        this._detectEdgeSkew = 'scale';
         this._ghost.data.offset = new paper.Point(0, 0);
         this._ghost.data.scale = new paper.Point(1, 1);
         this._ghost.data.transform = new paper.Matrix();
@@ -424,14 +425,29 @@ class SelectionWidget {
                 distEdge = edgeLocal.subtract(unrotatedPivot),
                 distMovedEdge = distEdge.add(deltaLocal);
             this._ghost.data.transform.reset();
-            if (!modifiers.skew || (modifiers.skew && e.modifiers.shift)) {
+            if (this._detectEdgeSkew) {
+                if (e.modifiers.command || e.modifiers.alt || e.modifiers.shift)
+                    this._detectEdgeSkew = false;
+                else {
+                    const SKEW_SWITCH_DISTANCE = 10 / paper.view.zoom;
+                    let tangent = vertical ? new paper.Point(1,0) : new paper.Point(0,1);
+                    tangent = this._shearPoint(tangent, this.boxShear, 0).rotate(this.boxRotation).normalize();
+                    let initialDelta = e.point.subtract(this._initialPoint);
+                    let skewComp = initialDelta.project(tangent), scaleComp = initialDelta.project([tangent.y, -tangent.x]);
+                    if (this._detectEdgeSkew === 'scale' && scaleComp.length <= SKEW_SWITCH_DISTANCE && skewComp.length >= SKEW_SWITCH_DISTANCE)
+                        this._detectEdgeSkew = 'skew';
+                    else if (this._detectEdgeSkew === 'skew' && scaleComp.length >= SKEW_SWITCH_DISTANCE)
+                        this._detectEdgeSkew = 'scale';
+                }
+            }
+            if ((!modifiers.skew || (modifiers.skew && e.modifiers.shift)) && this._detectEdgeSkew !== 'skew') {
                 var scaleFactor = distMovedEdge.divide(distEdge);
                 if (vertical) scaleFactor.x = 1;
                 else scaleFactor.y = 1;
                 
                 this._ghost.data.transform.scale(scaleFactor);
             }
-            if (modifiers.skew) {
+            if (modifiers.skew || this._detectEdgeSkew === 'skew') {
                 var shearFactor = deltaLocal.divide(this._ghost.bounds.height, this._ghost.bounds.width);
                 if (vertical) {
                     shearFactor.y = 0;

--- a/src/Editor/Panels/Inspector/Inspector.jsx
+++ b/src/Editor/Panels/Inspector/Inspector.jsx
@@ -573,6 +573,23 @@ class Inspector extends Component {
   }
 
   /**
+   * Renders an inspector row allowing viewing and editing of the selection's pivot x y position.
+   */
+  renderPivot = () => {
+    var { x, y } = this.getSelectionAttribute('relativePivot');
+    return (
+      <InspectorDualNumericInput
+        tooltip1="Pivot X"
+        tooltip2="Pivot Y"
+        val1={x}
+        val2={y}
+        onChange1={(val) => this.setSelectionAttribute('relativePivot', {x: val, y})}
+        onChange2={(val) => this.setSelectionAttribute('relativePivot', {x, y: val})}
+        id="inspector-pivot" />
+    )
+  }
+
+  /**
    * Renders an inspector row allowing viewing and editing of the selection's opacity.
    */
   renderOpacity = () => {
@@ -600,6 +617,7 @@ class Inspector extends Component {
         {this.renderScale()}
         {this.renderRotation()}
         {this.renderShear()}
+        {this.renderPivot()}
         {this.renderOpacity()}
       </div>
     )

--- a/src/Editor/Panels/MobileContainer/MobileInspector/MobileInspector.jsx
+++ b/src/Editor/Panels/MobileContainer/MobileInspector/MobileInspector.jsx
@@ -579,6 +579,27 @@ class MobileInspector extends Component {
   }
 
   /**
+   * Renders an inspector row allowing viewing and editing of the selection's pivot x y position.
+   */
+  renderPivot = () => {
+    var { x, y } = this.getSelectionAttribute('relativePivot');
+    return (
+      <MobileInspectorDualNumericInput
+        tooltip1="Pivot X"
+        tooltip2="Pivot Y"
+        icon1={xIcon}
+        iconAlt1="x Icon"
+        icon2={yIcon}
+        iconAlt2="Y Icon"
+        val1={x}
+        val2={y}
+        onChange1={(val) => this.setSelectionAttribute('relativePivot', {x: val, y})}
+        onChange2={(val) => this.setSelectionAttribute('relativePivot', {x, y: val})}
+        id="inspector-pivot" />
+    )
+  }
+
+  /**
    * Renders an inspector row allowing viewing and editing of the selection's opacity.
    */
   renderOpacity = () => {
@@ -615,6 +636,7 @@ class MobileInspector extends Component {
           iconAlt2="Shear Icon"
           shearVal={this.getSelectionAttribute('shear')}
           onShearChange={(val) => this.setSelectionAttribute('shear', val)} />
+        {this.renderPivot()}
       </div>
     )
   }


### PR DESCRIPTION
## Description
This PR adds:

- "Pivot X" and "Pivot Y" values to the inspector, both desktop and mobile. These are expressed in relative coordinates to the selection or single clip (before translation, scale, shear, and rotation are applied).

- Pivot snapping to the selection's corners, edge midpoints, and center. It can be disabled by holding `Alt` while dragging the pivot. The pivot snap distance is currently set to the pivot handle's radius.

- The ability to skew by dragging horizontally. This gets overridden when any modifier keys (`Ctrl`, `Shift`, `Alt`) are pressed. Currently set to skew within a vertical distance of 10

https://github.com/user-attachments/assets/63f19903-3774-4c21-95b7-287eedf47882

## Todo
- [ ] Add icons to mobile inspector pivot X/Y inputs

## Testing
Try entering different values for selection pivot X/Y in the inspector. Then move, scale, shear, and rotate the selection using the canvas tool: the values for pivot X/Y should not change.
Drag the pivot point close to the center, one of the corners, or one of the midpoints: at a close enough distance, the pivot should snap to these corners. This can be verified by viewing the pivot's exact coordinates in the inspector.

## Checklist
- [ ] This PR does not make sense to split up into smaller PRs. (I probably should've moved the skewing behavior to a separate PR but oh well)