### PR TITLE
fix: Audio sometimes not added to exports

### DIFF
--- a/engine/src/export/audio/AudioTrack.js
+++ b/engine/src/export/audio/AudioTrack.js
@@ -327,7 +327,7 @@ Wick.AudioTrack = class {
 
         var delayedBuffer = ctx.createBuffer(
             originalBuffer.numberOfChannels,
-            lengthOfDelay + lengthOfOriginalSound,
+            Math.round(lengthOfDelay + lengthOfOriginalSound),
             ctx.sampleRate,
         );
 


### PR DESCRIPTION
## Description
Several projects were reported to be missing certain audios in their `.mp4` exports. The bug: a `RangeError`, originating in [Wick.AudioTrack](https://github.com/Candlestickers/Candlestick/blob/8fa8a53d623040e633f43663c71639012c00a8e4/engine/src/export/audio/AudioTrack.js#L344). Further investigation uncovered a discrepancy in the two audio buffers' sizes: the output `delayedBuffer` contained one less element than `originalBuffer`, causing `Float32Array.set` to panic and fail to return the audio data.

The `length` of an `AudioBuffer` equals its `sampleRate` times its `duration`. `AudioTrack.addStartDelayToAudioBuffer` uses this to calculate the length of the output buffer:
```javascript
let lengthOfDelay = ctx.sampleRate * delaySeconds;
let lengthOfOriginalSound = ctx.sampleRate * originalBuffer.duration;
```
Under certain circumstances, however, the result of these multiplications is subjected to a floating-point error, returning such products as `199998.99999999997` instead of `199999`. As `AudioContext.createBuffer` requires an integer length, it discards the decimal part of this result, thus causing the `RangeError` and the audio's disappearance.

This PR rounds the length to the nearest integer, eliminating the miscalculation and, hopefully, solving the last audio mystery once and for all.

## Testing
1. Load one of the affected projects.
2. Export either a `.mp4` video or a `.wav` audio.
3. The audio should play in the export as expected.

## Checklist
- [x] This PR does not make sense to split into smaller PRs.