### PR TITLE
fix: Full rotation tweens don't tween properly

### DIFF
--- a/engine/src/Transformation.js
+++ b/engine/src/Transformation.js
@@ -66,14 +66,14 @@ Wick.Transformation = class {
         // https://github.com/paperjs/paper.js/blob/92775f5279c05fb7f0a743e9e7fa02cd40ec1e70/src/basic/Matrix.js#L687
         const { x, y, scaleX, scaleY, rotation } = this;
         const degrees = 180 / Math.PI,
-            rotateRad = rotation / degrees,
+            rotateRad = (rotation % 360) / degrees,
             skewRad = this.scaledSkew / degrees;
         let a, b, c, d;
         let r = scaleX, r2 = r * r,
             det = scaleY * r,
             at = Math.tan(skewRad) * r2;
         a = Math.cos(rotateRad) * r;
-        b = Math.sqrt(r2 - a * a) * (rotateRad > 0 ? 1 : -1);
+        b = Math.sqrt(r2 - a * a) * (rotateRad <= Math.PI ? 1 : -1);
         d = (b * at + a * det) / r2;
         c = (a * at - b * det) / r2;
         return [a, b, c, d, x, y];


### PR DESCRIPTION
## Description
With the new skew tweens feature, full rotations tween quite abnormally... whoops! The matrix-creating code I used didn't account for values over 180 degrees properly! Patched this up by ensuring angles are in the range `[0,360)` *before* using it in the transformation matrix code.

## Testing
1. Create a clip on an empty frame, then on the frame add a couple tweens.
2. Set "Full Rotations" of the first tween to 1.
3. Play the project. The clip should make one full clockwise rotation as expected.

## Checklist
- [x] This PR does not make sense to split up into smaller PRs.