### PR TITLE
fix: Clip break apart bugs with undo and pivot

### DIFF
--- a/engine/src/base/Clip.js
+++ b/engine/src/base/Clip.js
@@ -414,15 +414,18 @@ Wick.Clip = class extends Wick.Tickable {
         var leftovers = [];
 
         this.timeline.activeFrames.forEach(frame => {
-            frame.clips.forEach(clip => {
-                clip.transformation.x += this.transformation.x;
-                clip.transformation.y += this.transformation.y;
+            frame.clips.forEach(originalClip => {
+                // Keep original objects in case of undo
+                const clip = originalClip.copy();
+                clip.transformation.x += this.transformation.x - this.pivot[0];
+                clip.transformation.y += this.transformation.y - this.pivot[1];
                 this.parentTimeline.activeFrame.addClip(clip);
                 leftovers.push(clip);
             });
-            frame.paths.forEach(path => {
-                path.x += this.transformation.x;
-                path.y += this.transformation.y;
+            frame.paths.forEach(originalPath => {
+                const path = originalPath.copy();
+                path.x += this.transformation.x - this.pivot[0];
+                path.y += this.transformation.y - this.pivot[1];
                 this.parentTimeline.activeFrame.addPath(path);
                 leftovers.push(path);
             });


### PR DESCRIPTION
## Description
This pull request adds fixes for two bugs, that both occur when breaking clips apart. The first fix keeps the clips and paths intact so they don't disappear when you undo. The second takes the pivot point into account so all the contents of the clip appear at the locations where they should.
Closes #196

## Testing
1. Create a clip.
2. Break the clip apart then undo. All the clips frames should appear the same as before.
3. Move the clip's pivot then break apart. The broken-apart objects should not have appeared to move.

## Checklist
- [x] This PR does not make sense to split up into smaller PRs. (I mean, they're close enough to only use one PR)